### PR TITLE
Make it easier to change subscriber configuration

### DIFF
--- a/src/SendComics/SendComics.cs
+++ b/src/SendComics/SendComics.cs
@@ -2,6 +2,7 @@ namespace SendComics
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Net;
     using global::SendComics.Services;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Host;
@@ -20,11 +21,10 @@ namespace SendComics
             var log = new Logger(tracer);
             log.Info("Beginning execution");
 
+            var configurationString = new WebClient().DownloadString(Environment.GetEnvironmentVariable("SubscriberConfigurationLocation"));
             var comicMailBuilder = new ComicMailBuilder(
                 DateTime.Now.Date,
-                new ConfigurationParser(
-                    Environment.GetEnvironmentVariable("TestSubscriberConfiguration") ??
-                    Environment.GetEnvironmentVariable("SubscriberConfiguration")),
+                new ConfigurationParser(configurationString),
                 new WebComicFetcher(),
                 log);
 

--- a/src/SendComics/SendComics.cs
+++ b/src/SendComics/SendComics.cs
@@ -22,7 +22,7 @@ namespace SendComics
 
             var comicMailBuilder = new ComicMailBuilder(
                 DateTime.Now.Date,
-                new SimpleConfigurationParser(
+                new ConfigurationParser(
                     Environment.GetEnvironmentVariable("TestSubscriberConfiguration") ??
                     Environment.GetEnvironmentVariable("SubscriberConfiguration")),
                 new WebComicFetcher(),

--- a/src/SendComics/Services/ConfigurationParser.cs
+++ b/src/SendComics/Services/ConfigurationParser.cs
@@ -1,4 +1,4 @@
-namespace SendComics.Services
+﻿namespace SendComics.Services
 {
     using System;
     using System.Collections.Generic;
@@ -10,27 +10,27 @@ namespace SendComics.Services
     /// Parses a configuration string of the form
     /// emailaddress1: comic1a, comic1b, comic1c*2-20190101-20190430; emailaddress2: comic2a, comic2b, comic2c, …
     /// </summary>
-    public class SimpleConfigurationParser : IConfigurationSource
+    public class ConfigurationParser : IConfigurationSource
     {
-        private readonly string simpleConfiguration;
+        private readonly string configurationString;
 
-        public SimpleConfigurationParser(string simpleConfiguration)
+        public ConfigurationParser(string configurationString)
         {
-            this.simpleConfiguration = simpleConfiguration;
+            this.configurationString = configurationString;
         }
 
         public Configuration GetConfiguration()
         {
-            var commaSplitter = new Regex(", *");
-            var semicolonSplitter = new Regex("; *");
+            var comicSplitter = new Regex(", *");
+            var subscriberSplitter = new Regex("; *");
 
             var subscribers = new List<Subscriber>();
-            var subscriberStrings = semicolonSplitter.Split(this.simpleConfiguration);
+            var subscriberStrings = subscriberSplitter.Split(this.configurationString);
             foreach (var subscriberString in subscriberStrings)
             {
                 var colonIndex = subscriberString.IndexOf(": ", StringComparison.Ordinal);
                 var email = subscriberString.Substring(0, colonIndex);
-                var subscriptions = commaSplitter
+                var subscriptions = comicSplitter
                     .Split(subscriberString.Substring(colonIndex + 2))
                     .Select(CreateSubscription)
                     .ToArray();

--- a/src/SendComics/Services/ConfigurationParser.cs
+++ b/src/SendComics/Services/ConfigurationParser.cs
@@ -14,6 +14,7 @@
     ///   emailaddress2: comic2a, comic2b, comic2c
     ///   …
     /// which is preferred.
+    /// In the multi-line format, lines beginning with # are comments and are ignored.
     /// </summary>
     public class ConfigurationParser : IConfigurationSource
     {
@@ -32,7 +33,8 @@
             var subscribers = new List<Subscriber>();
             var subscriberStrings = subscriberSplitter
                 .Split(this.configurationString)
-                .Where(s => !string.IsNullOrWhiteSpace(s));
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Where(s => !s.StartsWith("#", StringComparison.InvariantCulture));
             foreach (var subscriberString in subscriberStrings)
             {
                 var colonIndex = subscriberString.IndexOf(": ", StringComparison.Ordinal);

--- a/src/SendComics/Services/ConfigurationParser.cs
+++ b/src/SendComics/Services/ConfigurationParser.cs
@@ -8,7 +8,12 @@
 
     /// <summary>
     /// Parses a configuration string of the form
-    /// emailaddress1: comic1a, comic1b, comic1c*2-20190101-20190430; emailaddress2: comic2a, comic2b, comic2c, …
+    ///   emailaddress1: comic1a, comic1b, comic1c*2-20190101-20190430; emailaddress2: comic2a, comic2b, comic2c, …
+    /// or the multi-line variant
+    ///   emailaddress1: comic1a, comic1b, comic1c*2-20190101-20190430
+    ///   emailaddress2: comic2a, comic2b, comic2c
+    ///   …
+    /// which is preferred.
     /// </summary>
     public class ConfigurationParser : IConfigurationSource
     {
@@ -22,10 +27,12 @@
         public Configuration GetConfiguration()
         {
             var comicSplitter = new Regex(", *");
-            var subscriberSplitter = new Regex("; *");
+            var subscriberSplitter = new Regex(@"; *|[\r\n]+");
 
             var subscribers = new List<Subscriber>();
-            var subscriberStrings = subscriberSplitter.Split(this.configurationString);
+            var subscriberStrings = subscriberSplitter
+                .Split(this.configurationString)
+                .Where(s => !string.IsNullOrWhiteSpace(s));
             foreach (var subscriberString in subscriberStrings)
             {
                 var colonIndex = subscriberString.IndexOf(": ", StringComparison.Ordinal);

--- a/tests/SendComics.IntegrationTests/ComicMailBuilderTests.cs
+++ b/tests/SendComics.IntegrationTests/ComicMailBuilderTests.cs
@@ -33,7 +33,7 @@ namespace SendComics.IntegrationTests
             {
                 var target = new ComicMailBuilder(
                     DateTime.Now,
-                    new SimpleConfigurationParser("blair.conrad@gmail.com: dilbert, 9chickweedlane"),
+                    new ConfigurationParser("blair.conrad@gmail.com: dilbert, 9chickweedlane"),
                     fakeComicFetcher.Object,
                     A.Dummy<ILogger>());
 
@@ -61,7 +61,7 @@ namespace SendComics.IntegrationTests
                 var now = DateTime.Now;
                 var target = new ComicMailBuilder(
                     now,
-                    new SimpleConfigurationParser($"blair.conrad@gmail.com: breaking-cat-news*2-20170327-{now.ToString("yyyyMMdd", CultureInfo.InvariantCulture)}"),
+                    new ConfigurationParser($"blair.conrad@gmail.com: breaking-cat-news*2-20170327-{now.ToString("yyyyMMdd", CultureInfo.InvariantCulture)}"),
                     fakeComicFetcher.Object,
                     A.Dummy<ILogger>());
 
@@ -87,7 +87,7 @@ namespace SendComics.IntegrationTests
             var fakeComicFetcher = A.Fake<IComicFetcher>();
             var target = new ComicMailBuilder(
                 today,
-                new SimpleConfigurationParser($"blair.conrad@gmail.com: breaking-cat-news*5-20190217-20190219"),
+                new ConfigurationParser($"blair.conrad@gmail.com: breaking-cat-news*5-20190217-20190219"),
                 fakeComicFetcher,
                 A.Dummy<ILogger>());
 
@@ -104,7 +104,7 @@ namespace SendComics.IntegrationTests
             var fakeComicFetcher = A.Fake<IComicFetcher>();
             var target = new ComicMailBuilder(
                 today,
-                new SimpleConfigurationParser("blair.conrad@gmail.com: breaking-cat-news*3-20170327-20190328"),
+                new ConfigurationParser("blair.conrad@gmail.com: breaking-cat-news*3-20170327-20190328"),
                 fakeComicFetcher,
                 A.Dummy<ILogger>());
 
@@ -124,7 +124,7 @@ namespace SendComics.IntegrationTests
             {
                 var target = new ComicMailBuilder(
                     DateTime.Now,
-                    new SimpleConfigurationParser("blair.conrad@gmail.com: 9chickweedlane; anyone@mail.org: dilbert"),
+                    new ConfigurationParser("blair.conrad@gmail.com: 9chickweedlane; anyone@mail.org: dilbert"),
                     fakeComicFetcher.Object,
                     A.Dummy<ILogger>());
 
@@ -155,7 +155,7 @@ namespace SendComics.IntegrationTests
             {
                 var target = new ComicMailBuilder(
                     new DateTime(2019, 7, 14),
-                    new SimpleConfigurationParser("blair.conrad@gmail.com: blondie, rhymes-with-orange"),
+                    new ConfigurationParser("blair.conrad@gmail.com: blondie, rhymes-with-orange"),
                     fakeComicFetcher.Object,
                     A.Dummy<ILogger>());
 
@@ -179,7 +179,7 @@ namespace SendComics.IntegrationTests
 
             var target = new ComicMailBuilder(
                 new DateTime(2018, 6, 27),
-                new SimpleConfigurationParser($"blair.conrad@gmail.com: {comic}"),
+                new ConfigurationParser($"blair.conrad@gmail.com: {comic}"),
                 fakeComicFetcher,
                 A.Dummy<ILogger>());
 
@@ -202,7 +202,7 @@ namespace SendComics.IntegrationTests
             {
                 var target = new ComicMailBuilder(
                     dateToCheck,
-                    new SimpleConfigurationParser("blair.conrad@gmail.com: dinosaur-comics"),
+                    new ConfigurationParser("blair.conrad@gmail.com: dinosaur-comics"),
                     fakeComicFetcher.Object,
                     A.Dummy<ILogger>());
 
@@ -233,7 +233,7 @@ namespace SendComics.IntegrationTests
             {
                 var target = new ComicMailBuilder(
                     dateToCheck,
-                    new SimpleConfigurationParser("blair.conrad@gmail.com: dinosaur-comics"),
+                    new ConfigurationParser("blair.conrad@gmail.com: dinosaur-comics"),
                     fakeComicFetcher.Object,
                     A.Dummy<ILogger>());
 
@@ -265,7 +265,7 @@ namespace SendComics.IntegrationTests
             {
                 var target = new ComicMailBuilder(
                     dateToCheck,
-                    new SimpleConfigurationParser("blair.conrad@gmail.com: foxtrot"),
+                    new ConfigurationParser("blair.conrad@gmail.com: foxtrot"),
                     fakeComicFetcher.Object,
                     A.Dummy<ILogger>());
 
@@ -291,7 +291,7 @@ namespace SendComics.IntegrationTests
             {
                 var target = new ComicMailBuilder(
                     dateToCheck,
-                    new SimpleConfigurationParser("blair.conrad@gmail.com: foxtrot"),
+                    new ConfigurationParser("blair.conrad@gmail.com: foxtrot"),
                     fakeComicFetcher.Object,
                     A.Dummy<ILogger>());
 
@@ -317,7 +317,7 @@ namespace SendComics.IntegrationTests
                 var dateToCheck = MostRecent(DayOfWeek.Sunday);
                 var target = new ComicMailBuilder(
                     dateToCheck,
-                    new SimpleConfigurationParser("blair.conrad@gmail.com: calvinandhobbes"),
+                    new ConfigurationParser("blair.conrad@gmail.com: calvinandhobbes"),
                     fakeComicFetcher.Object,
                     A.Dummy<ILogger>());
 
@@ -344,7 +344,7 @@ namespace SendComics.IntegrationTests
 
             var target = new ComicMailBuilder(
                 DateTime.Now,
-                new SimpleConfigurationParser("blair.conrad@gmail.com: rhymeswithorange, dilbert"),
+                new ConfigurationParser("blair.conrad@gmail.com: rhymeswithorange, dilbert"),
                 fakeComicFetcher,
                 A.Dummy<ILogger>());
 

--- a/tests/SendComics.IntegrationTests/ComicMailBuilderTests.cs
+++ b/tests/SendComics.IntegrationTests/ComicMailBuilderTests.cs
@@ -208,6 +208,35 @@ blair.conrad@gmail.com: 9chickweedlane
         }
 
         [Fact]
+        public static void TwoSubscribersOneEmphatic_BuildsOneMailForEmphatic()
+        {
+            IList<Mail> mails = null;
+
+            using (var fakeComicFetcher = SelfInitializingFake<IComicFetcher>.For(
+                () => new WebComicFetcher(),
+                new XmlFileRecordedCallRepository("../../../RecordedCalls/TwoSubscribersOneEmphatic_BuildsOneMailForEmphatic.xml")))
+            {
+                var target = new ComicMailBuilder(
+                    DateTime.Now,
+                    new ConfigurationParser(@"
+blair.conrad@gmail.com: 9chickweedlane
+! anyone@mail.org: dilbert
+".TrimStart()),
+                    fakeComicFetcher.Object,
+                    A.Dummy<ILogger>());
+
+                mails = target.CreateMailMessage().ToList();
+            }
+
+            mails.Should().HaveCount(1);
+
+            mails[0].From.Address.Should().Be("comics@blairconrad.com");
+            mails[0].Contents[0].Value.Should().Contain(DilbertImageUrl);
+            mails[0].Personalization[0].Tos.Should().HaveCount(1);
+            mails[0].Personalization[0].Tos[0].Address.Should().Be("anyone@mail.org");
+        }
+
+        [Fact]
         public static void SubscribesToComicsKingdomComics_BuildsOneMailWithBothComics()
         {
             IList<Mail> mails = null;

--- a/tests/SendComics.IntegrationTests/RecordedCalls/TwoSubscribersOnSeparateLinesOneComicEach_BuildsTwoMailsEachWithOneComic.xml
+++ b/tests/SendComics.IntegrationTests/RecordedCalls/TwoSubscribersOnSeparateLinesOneComicEach_BuildsTwoMailsEachWithOneComic.xml
@@ -1,0 +1,6698 @@
+<?xml version="1.0"?>
+<ArrayOfRecordedCall xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <RecordedCall>
+    <Method>System.String GetContent(System.Uri)</Method>
+    <ReturnValue xsi:type="xsd:string">&lt;!DOCTYPE html&gt;
+&lt;html lang="en"&gt;
+  &lt;head&gt;
+      &lt;title&gt;9 Chickweed Lane by Brooke McEldowney for July 16, 2019 - GoComics&lt;/title&gt;
+
+      &lt;!--- MOBILE SCALE --&gt;
+  &lt;meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5.0, minimum-scale=1, user-scalable=yes"/&gt;
+	&lt;meta http-equiv="cleartype" content="on" /&gt;
+	&lt;meta http-equiv="Content-type" content="text/html;charset=UTF-8"&gt;
+	&lt;meta name='HandheldFriendly' content='True' /&gt;
+	&lt;meta name='MobileOptimized' content='320' /&gt;
+  
+  &lt;meta name="csrf-param" content="authenticity_token" /&gt;
+&lt;meta name="csrf-token" content="x+IUY32YD0KIgEhSqwuwASkH/hWbkuomsKKWhIXIIUfBFBWdcyVutaDsOKR8BIcBrr5JG8XBKHRJJS5e0wnJZQ==" /&gt;
+
+      &lt;link rel="canonical" href="https://www.gocomics.com/9chickweedlane/2019/07/16"&gt;    &lt;!-- Dynamic General Tags --&gt;
+&lt;!-- &lt;link rel="image_src" href="" /&gt; --&gt;
+&lt;meta name="keywords" content="9 Chickweed Lane July 16, 2019, Comic Strip for 9 Chickweed Lane, 9 Chickweed Lane, Cartoonist Brooke McEldowney, 9 Chickweed Lane GoComics, Comics, editorial cartoons, email comics, comic strips" /&gt;
+&lt;meta name="description" content="View the comic strip for 9 Chickweed Lane by cartoonist Brooke McEldowney created July 16, 2019 available on GoComics.com" /&gt;
+
+&lt;!-- Feature Item Sharing --&gt;
+&lt;!-- Facebook Open Graph Tags --&gt;
+&lt;meta property="og:url" content="https://www.gocomics.com/9chickweedlane/2019/07/16" /&gt;
+&lt;meta property="og:type" content="article" /&gt;
+&lt;meta property="og:title" content="9 Chickweed Lane by Brooke McEldowney for July 16, 2019 | GoComics.com" /&gt;
+&lt;meta property="og:image" content="https://assets.amuniversal.com/d4571e307e420137a88c005056a9545d" /&gt;
+&lt;meta property="og:image:height" content="282" /&gt;
+&lt;meta property="og:image:width" content="900" /&gt;
+&lt;meta property="og:description" content="" /&gt;
+&lt;meta property="og:site_name" content="GoComics" /&gt;
+&lt;meta property="fb:app_id" content="1747171135497727" /&gt;
+
+&lt;!-- Dynamic Twitter Card Meta Tags --&gt;
+&lt;meta name="twitter:card" content="photo"&gt;
+&lt;meta name="twitter:site" content="@GoComics"&gt;
+&lt;meta name="twitter:url" content="https://www.gocomics.com/9chickweedlane/2019/07/16"&gt;
+&lt;meta name="twitter:title" content="9 Chickweed Lane by Brooke McEldowney for July 16, 2019 | GoComics.com"&gt;
+&lt;meta name="twitter:description" content="July 16, 2019"&gt;
+&lt;meta name="twitter:image" content="https://assets.amuniversal.com/d4571e307e420137a88c005056a9545d"&gt;
+
+&lt;!-- Other OG Tags --&gt;
+&lt;meta property="article:published_time" content="2019-07-16" /&gt;
+&lt;meta property="article:author" content="Brooke McEldowney" /&gt;
+&lt;meta property="article:section" content="comic" /&gt;
+&lt;meta property="article:tag" content="" /&gt;
+
+
+  &lt;!-- Pinterest Verification --&gt;
+  &lt;meta name="p:domain_verify" content="2daa671e72ed57aab721dcad175fc876"/&gt;
+
+  &lt;!-- Webmaster Verification Tag --&gt;
+  &lt;meta name="msvalidate.01" content="CA2B093E89A42FE68A7281E53F12B64D" /&gt;
+  &lt;meta name="google-site-verification" content="iggzxjEv3099Ou5--yot5AOC_AcxqiS1g8kCGLfpSi8" /&gt;
+    	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-57x57-5f4787a1e81ece88fd748a38920a8490ba30c4c1765bb4c3a5fe8ac6d3b23d52.png" sizes="57x57" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-60x60-66c17bfd7a2544bc1d56606fffecd4b9e21bea4cfd1158eea09b873bd9ba9e8f.png" sizes="60x60" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-72x72-7b079675c10869aa5106bc43c97fd51dcd9704e7a728b0927e59a3fa9d7984ee.png" sizes="72x72" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-76x76-fde94b7ab5a5241b10f972616eecc506dca67803d2b41c8656661782cb5a20bf.png" sizes="76x76" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-114x114-1b749de56e3cb177db872794312fb2c8f78d75cdd8b44c81e0a8583f37d9e834.png" sizes="114x114" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-120x120-e0491d8c956f38a60431f0545d71d35f3acb7bdf58498d6f34a51c92d59a870d.png" sizes="120x120" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-144x144-5a7d4892325d4c929dc8b809c95d36ed2bfde766956e33f4afb73074bf6edfdb.png" sizes="144x144" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-152x152-12d6d62e9635b25ed3d0c31a35e7d8c2249c3ae239aee23dcba5cd908da0ef69.png" sizes="152x152" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-180x180-db8274b4743e90bff418f28febaf069fca79df4c809d6fe25bc0402078d6c0ea.png" sizes="180x180" /&gt;
+	&lt;link rel="icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/favicon-32x32-224453efe388a04d04596959b7d54d52dd64143ab36a1e967af5fc506637b71f.png" sizes="32x32" /&gt;
+	&lt;link rel="icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/favicon-96x96-92f1ac367fd0f34bc17956ef33d79433ddbec62144ee17b40add7a6a2ae6e61a.png" sizes="96x96" /&gt;
+	&lt;link rel="icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/favicon-16x16-6b66b8ce06776f4bfd528fef18b1345758f780a4d5c60edc6ddf02151721d3f4.png" sizes="16x16" /&gt;
+	&lt;link rel="manifest" href="https://assets.gocomics.com/assets/favicons/manifest-27eca3e8297eb7ff340deb3849b210185a459b3845456aa4d0036f6d966b3518.json" /&gt;
+	&lt;meta name="msapplication-TileColor" content="#ffffff" /&gt;
+	&lt;meta name="msapplication-TileImage" content="https://assets.gocomics.com/assets/favicons/ms-icon-144x144-5a7d4892325d4c929dc8b809c95d36ed2bfde766956e33f4afb73074bf6edfdb.png" /&gt;
+	&lt;meta name="theme-color" content="#ffffff" /&gt;
+    &lt;link rel="stylesheet" media="all" href="https://assets.gocomics.com/assets/application-gc-1d140142105c4833d80f665b09c6c6817b3304d00e6d48853069008a417036be.css" /&gt;
+    &lt;script src="https://assets.gocomics.com/assets/application-gc-preload-590b2dbef8d985bc4f074211bf82ace762630acac84c3bf0809b8d58017d64fa.js"&gt;&lt;/script&gt;
+
+    &lt;!-- Confiant --&gt;
+&lt;script async="" src="https://confiant-integrations.global.ssl.fastly.net/URCY_lYNAEeMRZShS4CoaDXuIew/gpt_and_prebid/config.js"&gt;&lt;/script&gt;
+
+&lt;!-- Prebid Wrapper --&gt;
+&lt;script src="https://assets.gocomics.com/assets/ad-dependencies-bac6f666726b60bf0d10ac1a15b24a0faab86db58c7dbc154274d8868c767982.js"&gt;&lt;/script&gt;
+
+&lt;!-- Venatus Market Ad-Manager (gocomics.com) --&gt;
+&lt;script&gt;
+    (function(){document.write('&lt;div id="vmv3-ad-manager" style="display:none"&gt;&lt;/div&gt;');document.getElementById("vmv3-ad-manager").innerHTML='&lt;iframe id="vmv3-frm" src="javascript:\'&lt;html&gt;&lt;body&gt;&lt;/body&gt;&lt;/html&gt;\'" width="0" height="0" data-mode="scan" data-site-id="5b04343a46e0fb0001162107"&gt;&lt;/iframe&gt;';var a=document.getElementById("vmv3-frm");a=a.contentWindow?a.contentWindow:a.contentDocument;a.document.open();a.document.write('&lt;script src="https://hb.vntsm.com/v3/live/ad-manager.min.js" type="text/javascript" async&gt;'+'&lt;/scr'+'ipt&gt;');a.document.close()})();
+&lt;/script&gt;
+&lt;!-- / Venatus Market Ad-Manager (gocomics.com) --&gt;
+
+&lt;!-- GPT --&gt;
+&lt;script async="async" src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"&gt;&lt;/script&gt;
+
+&lt;!-- Amazon --&gt;
+&lt;script&gt;
+    !function(a9,a,p,s,t,A,g){if(a[a9])return;function q(c,r){a[a9]._Q.push([c,r])}a[a9]={init:function(){q("i",arguments)},fetchBids:function(){q("f",arguments)},setDisplayBids:function(){},targetingKeys:function(){return[]},_Q:[]};A=p.createElement(s);A.async=!0;A.src=t;g=p.getElementsByTagName(s)[0];g.parentNode.insertBefore(A,g)}("apstag",window,document,"script","////c.amazon-adsystem.com/aax2/apstag.js");
+&lt;/script&gt;
+
+&lt;script&gt;
+    /***** Helper functions for ads *****/
+    var storeQueryString = function(){
+        var queryString = window.location.search.substring(1).split('&amp;');
+        for(var i=0; i&lt;queryString.length; i++){
+            var pair = queryString[i].split('=');
+            if(pair.length === 2){
+                amu_ads.query_string[pair[0]] = pair[1];
+            }
+        }
+    };
+
+    var findAds = function(className) {
+        var ads = document.getElementsByClassName(className);
+        ads = Array.prototype.slice.call(ads);
+        ads.map(function(element) {element.classList.remove(className);});
+
+        return ads
+    };
+
+    var getAdInfo = function (adElements) {
+        var adIds = adElements.map(getElementInfo);
+        adIds = adIds.filter(adSlotConfigExists).filter(servesAtBreakpoint);
+
+        return adIds;
+    };
+
+    var getAdSlot = function (slotInfo) {
+        return amu_ads.adSlots[slotInfo.id];
+    };
+
+    var adSlotConfigExists = function(slotInfo){
+        return typeof amu_ads.adSlotConfig[slotInfo.adType] !== 'undefined';
+    };
+
+    var servesAtBreakpoint = function(slotInfo){
+        var curBpt = amu_ads.adSlotConfig[slotInfo.adType].breakpoint;
+        return curBpt.sizes.length &gt; 0;
+    };
+
+    var getElementId = function(element){
+        return element.id;
+    };
+
+    var getElementAdType = function(element){
+        return element.getAttribute('data-ad-type');
+    };
+
+    var getElementInfo = function(element){
+        return {id: getElementId(element), adType: getElementAdType(element)};
+    };
+
+    var findBreakpoint = function(breakpointsArray){
+        var maxBpt, curBpt;
+        for (var i = 0; i &lt; breakpointsArray.length; i++) {
+            curBpt = breakpointsArray[i];
+            if (amu_ads.browserWidth &gt;= curBpt.minWidth &amp;&amp; amu_ads.browserHeight &gt;= curBpt.minHeight){
+                if(!maxBpt || (curBpt.minWidth &gt;= maxBpt.minWidth &amp;&amp; curBpt.minHeight &gt;= maxBpt.minHeight)){
+                    maxBpt = curBpt;
+                }
+            }
+        }
+        return maxBpt
+    };
+
+
+    var updatePageviewTargeting = function() {
+        var adPageview = getPageviewFromCookie();
+        Object.keys(amu_ads.adSlotConfig).forEach(function(key) {
+            amu_ads.adSlotConfig[key].targeting['pv'] = adPageview;
+        });
+    };
+
+    var adLazyLoaderInit = function (className) {
+        var adElements = Array.prototype.slice.call(document.getElementsByClassName(className));
+
+        adElements.forEach(function(element) {
+            element.classList.remove(className);
+            amu_ads.adLazyLoader.observe(element);
+        });
+    };
+
+    var adRefresherInit = function (className) {
+        if(!isEU){
+            var adElements = Array.prototype.slice.call(document.getElementsByClassName(className));
+
+            adElements.forEach(function(element) {
+                element.classList.remove(className);
+                amu_ads.adRefresher.observe(element);
+            });
+
+            if(typeof(amu_ads.adRefreshInterval) === 'undefined') {
+                amu_ads.adRefreshInterval = window.setInterval(handleAdRefreshInterval, amu_ads.adRefreshRate);
+            }
+        }
+    };
+
+    var handleAdLazyLoad = function (entries, observer) {
+        entries.forEach(function(entry) {
+            if(entry.isIntersecting){
+                // run auction on these elements
+                var adInfo = getAdInfo([entry.target]);
+                auctionInit(adInfo, false);
+                amu_ads.adLazyLoader.unobserve(entry.target);
+            }
+        });
+    };
+
+    var handleAdRefresh = function (entries, observer) {
+        var curAdId, curAdElement;
+        entries.forEach(function(entry) {
+            curAdElement = entry.target;
+            curAdId = curAdElement.id;
+            if(entry.intersectionRatio &gt;= 0.50) {
+                if(amu_ads.adSlots[curAdId]){
+                    amu_ads.inViewAds[curAdId] = curAdElement;
+                }
+            } else {
+                delete amu_ads.inViewAds[curAdId];
+            }
+        });
+    };
+
+    var handleAdRefreshInterval = function () {
+        if(amu_ads.adRefreshCount &lt; amu_ads.adRefreshMax) {
+            if(!document.hidden){
+
+                // Refresh in view ads
+                var adInfo = getAdInfo(Object.values(amu_ads.inViewAds));
+                auctionInit(adInfo, true);
+                // Update refresh count and clear inViewAds
+                amu_ads.adRefreshCount += 1;
+            }
+        } else {
+
+            // Stop refreshing
+            clearInterval(amu_ads.adRefreshInterval)
+        }
+    }
+
+&lt;/script&gt;
+&lt;script&gt;
+    // Global variable for advertising config
+    var amu_ads = amu_ads || {};
+
+    // Query string for changing ad slot path and ad channel
+    amu_ads.query_string = amu_ads.query_string || {};
+
+    // Browser and page info
+    amu_ads.browserWidth = "CSS1Compat" == window.document.compatMode ? window.document.documentElement.clientWidth : window.document.body.clientWidth;
+    amu_ads.browserHeight = "CSS1Compat" == window.document.compatMode ? window.document.documentElement.clientHeight : window.document.body.clientHeight;
+    amu_ads.pageDomain = window.location.hostname;
+    amu_ads.pagePath = window.location.pathname + location.search + location.hash;
+
+    // Ad channel (a or b)
+    amu_ads.adChannel = 'a';
+
+    // Current page view number (based on cookie)
+    amu_ads.adPageview = setPageviewCookie();
+
+    // Ad unit path
+    amu_ads.adSlotPath = '/19196947/gocomics.com/comic/cw';
+
+
+    // Intersection observer for lazy loading ads
+    amu_ads.adLazyLoadOptions = {
+        rootMargin: amu_ads.browserWidth &gt;= 992 ? '300px' : '200px',
+        threshold: 0
+    };
+    amu_ads.adLazyLoader = new IntersectionObserver(handleAdLazyLoad, amu_ads.adLazyLoadOptions);
+
+
+    // Intersection observer for refreshing in view ads
+    amu_ads.adRefreshOptions = {
+        threshold: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+    };
+    amu_ads.adRefresher = new IntersectionObserver(handleAdRefresh, amu_ads.adRefreshOptions);
+    amu_ads.inViewAds = {};
+    amu_ads.adRefreshCount = 0;
+    amu_ads.adRefreshMax = 5;
+    amu_ads.adRefreshRate = 30000;
+
+    // Place to store DFP ad slots (needed in order to refresh ads)
+    amu_ads.adSlots = {};
+
+
+
+    /***** Bidder config *****/
+    // AppNexus tag config
+    amu_ads.appnexusTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337721,
+                keywords: {
+                    pos: ['top'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_1': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337722,
+                keywords: {
+                    pos: ['mid_1'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_2': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337723,
+                keywords: {
+                    pos: ['mid_2'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 320x50
+        'locked': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337724,
+                keywords: {
+                    pos: ['locked'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 728x90
+        'bot': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337725,
+                keywords: {
+                    pos: ['bot'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '1': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337716,
+                keywords: {
+                    pos: ['1'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 300x250
+        '2': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337720,
+                keywords: {
+                    pos: ['2'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'right': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337717,
+                keywords: {
+                    pos: ['right'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'left': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337718,
+                keywords: {
+                    pos: ['left'],
+                    channel: [amu_ads.adChannel]
+                }
+
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'comments': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337719,
+                keywords: {
+                    pos: ['comments'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        }
+    };
+
+    // Index tag config
+    amu_ads.ixTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        '970x250_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '267537',
+                size: [970,250]
+            }
+        },
+        '970x90_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '267537',
+                size: [970,90]
+            }
+        },
+        '728x90_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '267537',
+                size: [728,90]
+            }
+        },
+        '320x50_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '267537',
+                size: [320,50]
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        '970x90_mid_1': {
+            bidder: 'ix',
+            params: {
+                siteId: '267538',
+                size: [970,90]
+            }
+        },
+        '728x90_mid_1': {
+            bidder: 'ix',
+            params: {
+                siteId: '267538',
+                size: [728,90]
+            }
+        },
+        '320x50_mid_1': {
+            bidder: 'ix',
+            params: {
+                siteId: '267538',
+                size: [320,50]
+            }
+        },
+        '300x250_mid_1': {
+            bidder: 'ix',
+            params: {
+                siteId: '267538',
+                size: [300,250]
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        '970x90_mid_2': {
+            bidder: 'ix',
+            params: {
+                siteId: '267539',
+                size: [970,90]
+            }
+        },
+        '728x90_mid_2': {
+            bidder: 'ix',
+            params: {
+                siteId: '267539',
+                size: [728,90]
+            }
+        },
+        '320x50_mid_2': {
+            bidder: 'ix',
+            params: {
+                siteId: '267539',
+                size: [320,50]
+            }
+        },
+        '300x250_mid_2': {
+            bidder: 'ix',
+            params: {
+                siteId: '267539',
+                size: [300,250]
+            }
+        },
+
+        // 320x50
+        '320x50_locked': {
+            bidder: 'ix',
+            params: {
+                siteId: '267540',
+                size: [320,50]
+            }
+        },
+
+        // 728x90
+        '728x90_bot': {
+            bidder: 'ix',
+            params: {
+                siteId: '267541',
+                size: [728,90]
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '300x250_1': {
+            bidder: 'ix',
+            params: {
+                siteId: '267532',
+                size: [300,250]
+            }
+        },
+
+        // 300x250
+        '300x250_2': {
+            bidder: 'ix',
+            params: {
+                siteId: '267536',
+                size: [300,250]
+            }
+        },
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        '300x250_right': {
+            bidder: 'ix',
+            params: {
+                siteId: '267533',
+                size: [300,250]
+            }
+        },
+        '160x600_right': {
+            bidder: 'ix',
+            params: {
+                siteId: '267533',
+                size: [160,600]
+            }
+        },
+        '300x600_right': {
+            bidder: 'ix',
+            params: {
+                siteId: '267533',
+                size: [300,600]
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        '300x250_left': {
+            bidder: 'ix',
+            params: {
+                siteId: '267534',
+                size: [300,250]
+            }
+        },
+        '160x600_left': {
+            bidder: 'ix',
+            params: {
+                siteId: '267534',
+                size: [160,600]
+            }
+        },
+        '300x600_left': {
+            bidder: 'ix',
+            params: {
+                siteId: '267534',
+                size: [300,600]
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        '300x250_comments': {
+            bidder: 'ix',
+            params: {
+                siteId: '267535',
+                size: [300,250]
+            }
+        },
+        '160x600_comments': {
+            bidder: 'ix',
+            params: {
+                siteId: '267535',
+                size: [160,600]
+            }
+        },
+        '300x600_comments': {
+            bidder: 'ix',
+            params: {
+                siteId: '267535',
+                size: [300,600]
+            }
+        }
+    };
+
+    // OpenX tag config
+    amu_ads.openxTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'openx',
+            params: {
+                unit: 540023521,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'top',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_1': {
+            bidder: 'openx',
+            params: {
+                unit: 540023523,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'mid_1',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_2': {
+            bidder: 'openx',
+            params: {
+                unit: 540023535,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'mid_2',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 320x50
+        'locked': {
+            bidder: 'openx',
+            params: {
+                unit: 540023537,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'locked',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 728x90
+        'bot': {
+            bidder: 'openx',
+            params: {
+                unit: 540023544,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'bot',
+                    channel:
+                    amu_ads.adChannel
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '1': {
+            bidder: 'openx',
+            params: {
+                unit: 540023496,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: '1',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 300x250
+        '2': {
+            bidder: 'openx',
+            params: {
+                unit: 540023512,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: '2',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'right': {
+            bidder: 'openx',
+            params: {
+                unit: 540023499,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'right',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'left': {
+            bidder: 'openx',
+            params: {
+                unit: 540023507,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'left',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'comments': {
+            bidder: 'openx',
+            params: {
+                unit: 540023510,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'comments',
+                    channel: amu_ads.adChannel
+                }
+            }
+        }
+    };
+
+    // PubMatic tag config
+    amu_ads.pubmaticTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090029'
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_1': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090030'
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_2': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090031'
+            }
+        },
+
+        // 320x50
+        'locked': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090032'
+            }
+        },
+
+        // 728x90
+        'bot': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090033'
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '1': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090024'
+            }
+        },
+
+        // 300x250
+        '2': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090028'
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'right': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090025'
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'left': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090026'
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'comments': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090027'
+            }
+        }
+    };
+
+    // Rubicon tag config
+    amu_ads.rubiconTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935870,
+                visitor: {
+                    'pos': ['top'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_1': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935874,
+                visitor: {
+                    'pos': ['mid_1'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_2': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935876,
+                visitor: {
+                    'pos': ['mid_2'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 320x50
+        'locked': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935880,
+                visitor: {
+                    'pos': ['locked'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 728x90
+        'bot': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935884,
+                visitor: {
+                    'pos': ['bot'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '1': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935850,
+                visitor: {
+                    'pos': ['1'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 300x250
+        '2': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935864,
+                visitor: {
+                    'pos': ['2'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'right': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935854,
+                visitor: {
+                    'pos': ['right'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'left': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935878,
+                visitor: {
+                    'pos': ['left'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'comments': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935860,
+                visitor: {
+                    'pos': ['comments'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        }
+    };
+
+    // Sovrn tag config
+    amu_ads.sovrnTags = {
+        /***** Leaderboards and banners *****/
+        // 970x250, 728x90, 320x50
+        '970x250_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564744'
+            }
+        },
+        '728x90_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564745'
+            }
+        },
+        '320x50_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564746'
+            }
+        },
+
+        // 728x90, 320x50, 300x250
+        '728x90_mid_1': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564747'
+            }
+        },
+        '320x50_mid_1': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564748'
+            }
+        },
+        '300x250_mid_1': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '578781'
+            }
+        },
+
+        // 728x90, 320x50, 300x250
+        '728x90_mid_2': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564749'
+            }
+        },
+        '320x50_mid_2': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564750'
+            }
+        },
+        '300x250_mid_2': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '578782'
+            }
+        },
+
+        // 320x50
+        '320x50_locked': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564751'
+            }
+        },
+
+        // 728x90
+        '728x90_bot': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564752'
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '300x250_1': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564733'
+            }
+        },
+
+        // 300x250
+        '300x250_2': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564743'
+            }
+        },
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        '300x250_right': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564734'
+            }
+        },
+        '160x600_right': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564735'
+            }
+        },
+        '300x600_right': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564736'
+            }
+        },
+
+
+        // 300x250, 160x600, 300x600
+        '300x250_left': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564737'
+            }
+        },
+        '160x600_left': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564738'
+            }
+        },
+        '300x600_left': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564739'
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        '300x250_comments': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564740'
+            }
+        },
+        '160x600_comments': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564741'
+            }
+        },
+        '300x600_comments': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564742'
+            }
+        }
+
+    };
+
+    // AppNexus tag config
+    amu_ads.tripleliftTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_top_multisize',
+            }
+        },
+
+        // 728x90, 320x50, 300x250
+        'mid_1': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_mid_1_multisize',
+            }
+        },
+
+        // 728x90, 320x50, 300x250
+        'mid_2': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_mid_2_multisize',
+            }
+        },
+
+        // 320x50
+        'locked': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_locked_320x50_hdx',
+            }
+        },
+
+        // 728x90
+        'bot': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_bot_728x90',
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '1': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_rectangle1_300x250',
+            }
+        },
+
+        // 300x250
+        '2': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_rectangle2_300x250',
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'right': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_right_multisize_hdx',
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'left': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_left_multisize_hdx',
+
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'comments': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_comments_multisize_hdx',
+            }
+        }
+    };
+
+
+
+    /***** Ad config *****/
+    // TODO: refactor/consolidate ad slot configs when layouts are more consistent
+    amu_ads.adSlotConfig = {};
+    amu_ads.adSlotConfig['leaderboard'] = {
+        name: 'leaderboard',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'top',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 970,
+                minHeight: 850,
+                sizes: [[970, 90], [970, 250], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x250_top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['970x250_top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['320x50_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['leaderboard'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['leaderboard'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['leaderboard_home'] = {
+        name: 'leaderboard_home',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'top',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['320x50_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['leaderboard_home'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['leaderboard_home'].breakpoints);
+
+
+    // When setting leaderboard breakpoints remember to set the shortest size first in the sizes array to avoid screen bounce.
+    amu_ads.adSlotConfig['leaderboard_feature_item'] = {
+        name: 'leaderboard_feature_item',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'top',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1310,
+                minHeight: 850,
+                sizes: [[970, 90], [970, 250], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x250_top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['970x250_top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 1310,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 850,
+                sizes: [[970, 90], [970, 250], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x250_top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['970x250_top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['320x50_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['leaderboard_feature_item'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['leaderboard_feature_item'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['leaderboard_feature_overview'] = {
+        name: 'leaderboard_feature_overview',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'top',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1310,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['320x50_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['leaderboard_feature_overview'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['leaderboard_feature_overview'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner1'] = {
+        name: 'banner1',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'mid_1',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['728x90_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['728x90_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1'],
+                    amu_ads.tripleliftTags['mid_1']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['970x90_mid_1'],
+                    amu_ads.ixTags['728x90_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['728x90_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['728x90_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['728x90_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1'],
+                    amu_ads.tripleliftTags['mid_1']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['320x50_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['320x50_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1'],
+                    amu_ads.tripleliftTags['mid_1']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner1'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner1'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner2'] = {
+        name: 'banner2',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'mid_2',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['728x90_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['728x90_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2'],
+                    amu_ads.tripleliftTags['mid_2']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['970x90_mid_2'],
+                    amu_ads.ixTags['728x90_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['728x90_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['728x90_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['728x90_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2'],
+                    amu_ads.tripleliftTags['mid_2']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['320x50_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['320x50_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2'],
+                    amu_ads.tripleliftTags['mid_2']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner2'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner2'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner_explore1'] = {
+        name: 'banner_explore1',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'mid_1',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1145,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['728x90_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['728x90_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1'],
+                    amu_ads.tripleliftTags['mid_1']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['320x50_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['320x50_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1'],
+                    amu_ads.tripleliftTags['mid_1']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner_explore1'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner_explore1'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner_explore2'] = {
+        name: 'banner_explore2',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'mid_2',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1145,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['728x90_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['728x90_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2'],
+                    amu_ads.tripleliftTags['mid_2']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['320x50_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['320x50_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2'],
+                    amu_ads.tripleliftTags['mid_2']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner_explore2'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner_explore2'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner_bot'] = {
+        name: 'banner_bot',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'bot',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['bot'],
+                    amu_ads.ixTags['728x90_bot'],
+                    amu_ads.openxTags['bot'],
+                    amu_ads.pubmaticTags['bot'],
+                    amu_ads.rubiconTags['bot'],
+                    amu_ads.sovrnTags['728x90_bot'],
+                    amu_ads.tripleliftTags['bot']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner_bot'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner_bot'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner_lock'] = {
+        name: 'banner_lock',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'locked',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 768,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            },
+            {
+                minWidth: 0,
+                minHeight: 300,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['locked'],
+                    amu_ads.ixTags['320x50_locked'],
+                    amu_ads.openxTags['locked'],
+                    amu_ads.pubmaticTags['locked'],
+                    amu_ads.rubiconTags['locked'],
+                    amu_ads.sovrnTags['320x50_locked'],
+                    amu_ads.tripleliftTags['locked']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner_lock'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner_lock'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['rectangle1'] = {
+        name: 'rectangle1',
+        targeting: {
+            'fcode': 'cw',
+            'pos': '1',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['1'],
+                    amu_ads.ixTags['300x250_1'],
+                    amu_ads.openxTags['1'],
+                    amu_ads.pubmaticTags['1'],
+                    amu_ads.rubiconTags['1'],
+                    amu_ads.sovrnTags['300x250_1'],
+                    amu_ads.tripleliftTags['1']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['rectangle1'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['rectangle1'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['rectangle2'] = {
+        name: 'rectangle2',
+        targeting: {
+            'fcode': 'cw',
+            'pos': '2',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['2'],
+                    amu_ads.ixTags['300x250_2'],
+                    amu_ads.openxTags['2'],
+                    amu_ads.pubmaticTags['2'],
+                    amu_ads.rubiconTags['2'],
+                    amu_ads.sovrnTags['300x250_2'],
+                    amu_ads.tripleliftTags['2']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['rectangle2'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['rectangle2'].breakpoints);
+
+
+    amu_ads.adSlotConfig['rectangle_sidebar1'] = {
+        name: 'rectangle_sidebar1',
+        targeting: {
+            'fcode': 'cw',
+            'pos': '1',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['1'],
+                    amu_ads.ixTags['300x250_1'],
+                    amu_ads.openxTags['1'],
+                    amu_ads.pubmaticTags['1'],
+                    amu_ads.rubiconTags['1'],
+                    amu_ads.sovrnTags['300x250_1'],
+                    amu_ads.tripleliftTags['1']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['rectangle_sidebar1'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['rectangle_sidebar1'].breakpoints);
+
+
+    // TODO: rename to tower_comic or something later (Will need to coordinate with ADDKT)
+    amu_ads.adSlotConfig['tower'] = {
+        name: 'tower',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'right',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1200,
+                minHeight: 700,
+                sizes: [[300, 600], [160, 600], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x600_right'],
+                    amu_ads.ixTags['160x600_right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x600_right'],
+                    amu_ads.sovrnTags['160x600_right'],
+                    amu_ads.sovrnTags['300x250_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            },
+            {
+                minWidth: 1200,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x250_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 700,
+                sizes: [[160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['160x600_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['160x600_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tower_comments'] = {
+        name: 'tower_comments',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'comments',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 700,
+                sizes: [[300, 600], [160, 600], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['comments'],
+                    amu_ads.ixTags['300x600_comments'],
+                    amu_ads.ixTags['160x600_comments'],
+                    amu_ads.ixTags['300x250_comments'],
+                    amu_ads.openxTags['comments'],
+                    amu_ads.pubmaticTags['comments'],
+                    amu_ads.rubiconTags['comments'],
+                    amu_ads.sovrnTags['300x600_comments'],
+                    amu_ads.sovrnTags['160x600_comments'],
+                    amu_ads.sovrnTags['300x250_comments'],
+                    amu_ads.tripleliftTags['comments']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['comments'],
+                    amu_ads.ixTags['300x250_comments'],
+                    amu_ads.openxTags['comments'],
+                    amu_ads.pubmaticTags['comments'],
+                    amu_ads.rubiconTags['comments'],
+                    amu_ads.sovrnTags['300x250_comments'],
+                    amu_ads.tripleliftTags['comments']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_comments'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_comments'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tower_spotlight'] = {
+        name: 'tower_spotlight',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'right',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x250_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_spotlight'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_spotlight'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tower_nav'] = {
+        name: 'tower_nav',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'left',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1200,
+                minHeight: 700,
+                sizes: [[300, 600], [160, 600], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['300x600_left'],
+                    amu_ads.ixTags['160x600_left'],
+                    amu_ads.ixTags['300x250_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['300x600_left'],
+                    amu_ads.sovrnTags['160x600_left'],
+                    amu_ads.sovrnTags['300x250_left'],
+                    amu_ads.tripleliftTags['left']
+                ]
+            },
+            {
+                minWidth: 1200,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['300x250_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['300x250_left'],
+                    amu_ads.tripleliftTags['left']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 700,
+                sizes: [[160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['160x600_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['160x600_left'],
+                    amu_ads.tripleliftTags['left']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_nav'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_nav'].breakpoints);
+
+
+    amu_ads.adSlotConfig['tower_left'] = {
+        name: 'tower_left',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'left',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 700,
+                sizes: [[300, 600], [160, 600], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['300x600_left'],
+                    amu_ads.ixTags['160x600_left'],
+                    amu_ads.ixTags['300x250_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['300x600_left'],
+                    amu_ads.sovrnTags['160x600_left'],
+                    amu_ads.sovrnTags['300x250_left'],
+                    amu_ads.tripleliftTags['left']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['300x250_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['300x250_left'],
+                    amu_ads.tripleliftTags['left']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_left'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_left'].breakpoints);
+
+
+
+    // TODO: rename to tower or something later (will need to coordinate with ADDKT)
+    amu_ads.adSlotConfig['tower_explore'] = {
+        name: 'tower_explore',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'right',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 700,
+                sizes: [[300, 600], [160, 600], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x600_right'],
+                    amu_ads.ixTags['160x600_right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x600_right'],
+                    amu_ads.sovrnTags['160x600_right'],
+                    amu_ads.sovrnTags['300x250_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x250_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_explore'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_explore'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['sharethrough_home1'] = {
+        name: 'sharethrough_home1',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'sharethrough1',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel,
+            'strnativekey': 'ToUYV7H9xW7PLXQmvtACxrh1'
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[1, 1]],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['sharethrough_home1'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['sharethrough_home1'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['sharethrough_home2'] = {
+        name: 'sharethrough_home2',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'sharethrough2',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel,
+            'strnativekey': 'ToUYV7H9xW7PLXQmvtACxrh1'
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[1, 1]],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['sharethrough_home2'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['sharethrough_home2'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tynt'] = {
+        name: 'tynt',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'tynt',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[1, 1]],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tynt'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tynt'].breakpoints);
+&lt;/script&gt;
+
+&lt;script&gt;
+    // Venatus
+    var isEU = false;
+    window.VM_API = window.VM_API || [];
+
+    var PREBID_TIMEOUT = 1500;
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+    var customPriceBuckets = {
+        'buckets': [
+            // 1 cent increments up to 50 cents
+            {
+                'min': 0.00,
+                'max': 0.50,
+                'increment': 0.01
+            },
+            // 5 cent increments up to 5 dollars
+            {
+                'min': 0.50,
+                'max': 5.00,
+                'increment': 0.05
+            },
+            // 10 cent increments up to 10 dollars
+            {
+                'min': 5.00,
+                'max': 10.00,
+                'increment': 0.10
+            },
+            // 50 cent increments up to 20 dollars
+            {
+                'min': 10.00,
+                'max': 20.00,
+                'increment': 0.50
+            },
+            // 1 dollar increments up to 50 dollars
+            {
+                'min': 20.00,
+                'max': 50.00,
+                'increment': 1.00
+            }
+        ]
+    };
+
+    pbjs.que.push(function() {
+        pbjs.setConfig({
+            enableSendAllBids: true,
+            priceGranularity: customPriceBuckets,
+            userSync: {
+                iframeEnabled: true
+            }
+        });
+    });
+
+
+    // Confiant
+    // Wrapper for AMUniversal (GoComics), generated on 2018-10-26T16:40:06-04:00, version 2018.04.02
+    pbjs.que.push(function() {
+        // keep a reference to original renderAd function
+        var w = window;
+        w._clrm = w._clrm || {};
+        w._clrm.renderAd = w._clrm.renderAd || pbjs.renderAd;
+        var config = w._clrm.prebid || {
+            /* Enables sandboxing on a device group
+                 All:1 , Desktop:2, Mobile: 3, iOS: 4, Android: 5, Off: 0
+             */
+            sandbox: 0
+        };
+
+        var isGoogleFrame = function (c) {
+            return c.tagName === 'IFRAME' &amp;&amp; c.id &amp;&amp; c.id.indexOf('google_ads_iframe_') &gt; -1;
+        };
+
+        var shouldSandbox = function () {
+            var uaToRegexMap = {
+                    "mobile": /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/i,
+                    "ios": /(.+)(iPhone|iPad|iPod)(.+)OS[\s|\_](\d)\_?(\d)?[\_]?(\d)?.+/i,
+                    "android": /Android/i
+                },
+                sbStr = "" +config.sandbox;
+            if (sbStr === "1") {
+                // all environments
+                return true;
+            } else if (sbStr === "2") {
+                // desktop
+                return !navigator.userAgent.match(uaToRegexMap["mobile"]);
+            } else if (sbStr === "3") {
+                // mobile
+                return navigator.userAgent.match(uaToRegexMap["mobile"]);
+            } else if (sbStr === "4") {
+                // ios only
+                return navigator.userAgent.match(uaToRegexMap["ios"]);
+            } else if (sbStr === "5") {
+                // android
+                return navigator.userAgent.match(uaToRegexMap["android"]);
+            } else {
+                return false;
+            }
+        };
+
+        Node.prototype.appendChild = (function (original) {
+            return function (child) {
+                if (isGoogleFrame(child) &amp;&amp; shouldSandbox() &amp;&amp; !child.getAttribute('sandbox')) {
+                    child.setAttribute('sandbox', 'allow-forms allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation');
+                    child.setAttribute('data-forced-sandbox', true);
+                }
+                return original.call(this, child);
+            };
+        }(Node.prototype.appendChild));
+
+
+        // override renderAd
+        pbjs.renderAd = function(doc, id) {
+            if (doc &amp;&amp; id) {
+                try {
+
+                    // get pbjs bids
+                    var bids = [],
+                        bidResponses = pbjs.getBidResponses(),
+                        highestBids = pbjs.getHighestCpmBids();
+                    for (var slot in bidResponses) {
+                        bids = bids.concat(bidResponses[slot].bids);
+                    }
+                    bids = bids.concat(highestBids);
+
+                    // lookup ad by ad Id (avoid ES6 array functions)
+                    var bid, i;
+                    for (i=0; i&lt;bids.length; i++) {
+                        if (bids[i].adId === id) {
+                            bid = bids[i];
+                            break;
+                        }
+                    }
+
+                    // Optional: list of bidders that don't need wrapping, array of strings, e.g.: ["bidder1", "bidder2"]
+                    var confiantExcludeBidders = [];
+
+                    // check bidder exclusion (avoid ES6 array functions)
+                    var excludeBidder = false;
+                    for (i = 0; i &lt; confiantExcludeBidders.length; i++) {
+                        if (bid.bidder === confiantExcludeBidders[i]) {
+                            excludeBidder = true;
+                            break;
+                        }
+                    }
+
+                    if (bid &amp;&amp; bid.ad &amp;&amp; !excludeBidder) {
+                        // Neutralize document
+                        var docwrite = doc.write;
+                        var docclose = doc.close;
+                        doc.write = doc.close = function() {};
+                        // call renderAd with our neutralized doc.write
+                        window._clrm.renderAd(doc, id);
+                        // Restore document
+                        delete doc.write;
+                        delete doc.close;
+
+                        var callback = function(blockingType, blockingId, isBlocked, wrapperId, tagId, impressionData) {
+                            console.log("w00t one more bad ad nixed.", arguments);
+                        };
+
+                        return;
+                    }
+                } catch (e) {
+                    console.log(e);
+                }
+            }
+
+            // if bid.ad is not defined or if any error occurs, call renderAd to serve the creative
+            window._clrm.renderAd(doc, id);
+        };
+
+    });
+
+
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    googletag.cmd.push(function() {
+        googletag.pubads().disableInitialLoad();
+
+        // Event listener for when slot renders
+        googletag.pubads().addEventListener('slotRenderEnded', function(event) {
+            // Element Id of the slot
+            var slotId = event.slot.getSlotElementId();
+
+            // Update lock targets that load after initial page load
+            if(slotId === "tower_comments") {
+                gcLock.init('[data-gc-lock-depends="tower_comments"]');
+            } else if(slotId === "banner_lock") {
+                if(!event.isEmpty) {
+                    document.querySelector('.js-ad-banner-lock-wrapper').classList.remove('ad-hidden');
+                }
+            }
+        });
+    });
+
+    apstag.init({
+        pubID: 'af9aec0d-17e4-4619-825c-371fa3483a58',
+        adServer: 'googletag'
+    });
+&lt;/script&gt;
+
+&lt;script&gt;
+    function startAuction(bidTimeout, adInfo, adSlots, refresh) {
+        // Define bidders
+        var bidders = ['a9', 'prebid'];
+
+        // create a requestManager to keep track of bidder state to determine when to send ad server
+        // request and what apstagSlots to request from the ad server
+        var requestManager = {
+            adServerRequestSent: false
+        };
+        // add the bidders to the request manager:
+        bidders.forEach(function(bidder) {
+            requestManager[bidder] = false;
+        });
+
+        // return true if all bidders have returned
+        function allBiddersDone () {
+            return bidders.filter(function(bidder) {return requestManager[bidder];}).length === bidders.length;
+        }
+
+        // handler for header bidder responses
+        function bidderDone(bidder) {
+            if (requestManager.adServerRequestSent === false) {
+                // flip the boolean associated with the bidder in the request manager
+                requestManager[bidder] = true;
+
+                // if all bidders are back, send the request to the ad server
+                if (allBiddersDone()) {
+                    sendAdserverRequest(adInfo, adSlots, refresh);
+                }
+            }
+        }
+
+        // actually get ads from DFP
+        function sendAdserverRequest(adInfo, adSlots, refresh) {
+            if (requestManager.adServerRequestSent === false) {
+                requestManager.adServerRequestSent = true;
+                pbjs.que.push(function() {
+                    googletag.cmd.push(function() {
+                        if(!refresh){
+                            // 5. Display Ads
+                            displayAds(adInfo);
+                        }
+
+                        // 6. Refresh bids
+                        refreshAds(adSlots);
+                    });
+                });
+            }
+        }
+
+        function requestBids(adInfo, adSlots) {
+            // Fetch Amazon bids
+            amzn_fetchBids(adInfo, adSlots);
+
+            // Fetch Prebid bids
+            prebid_fetchBids(adInfo, adSlots);
+
+        }
+
+        /***** Amazon helper functions *****/
+        function amzn_buildSlotsArray(adInfo) {
+            var slotsArray = [];
+            var i, curAdId, curAdType;
+            for (i = 0; i &lt; adInfo.length; i++) {
+                curAdId = adInfo[i].id;
+                curAdType = adInfo[i].adType;
+                slotsArray.push({
+                    slotID: curAdId,
+                    sizes: amu_ads.adSlotConfig[curAdType].breakpoint.sizes
+                });
+            }
+            return slotsArray;
+
+        }
+
+        function amzn_fetchBids(adInfo, adSlots) {
+            // Fetch Amazon bids for slots on page
+            apstag.fetchBids(
+                {
+                    slots: amzn_buildSlotsArray(adInfo),
+                    timeout: 1000
+                },
+                function (bids) {
+                    pbjs.que.push(function () {
+                        googletag.cmd.push(function () {
+                            // Set Amazon bid key-values pairs
+                            try {
+                                apstag.setDisplayBids();
+                            } catch (e) {
+                                //do nothing
+                            }
+                        });
+                        bidderDone('a9', adInfo, adSlots);
+                    });
+                }
+            );
+        }
+
+        /* Prebid helper functions */
+        var prebid_fetchBids = function(adInfo, adSlots) {
+            var curAdIds = adInfo.map(function(e){return e.id;});
+            pbjs.que.push(function() {
+                pbjs.requestBids({
+                    timeout: PREBID_TIMEOUT,
+                    adUnitCodes: curAdIds,
+                    bidsBackHandler: function() {
+                        googletag.cmd.push(function() {
+                            pbjs.setTargetingForGPTAsync(curAdIds);
+                        });
+                        bidderDone('prebid', adInfo, adSlots);
+                    }
+                });
+            });
+        };
+
+        // ask bidders for their bids
+        requestBids(adInfo, adSlots);
+        // set timeout to send request to call sendAdserverRequest() after timeout
+        // it all bidders haven't returned before then
+        window.setTimeout(function() {
+            sendAdserverRequest(adInfo, adSlots);
+        }, bidTimeout);
+    }
+&lt;/script&gt;
+
+&lt;script&gt;
+    var buildAdUnits = function(adInfo) {
+        var adUnits = [];
+        var curUnit, curAdId, curAdType;
+        for(var i = 0; i &lt; adInfo.length; i++) {
+            curAdId = adInfo[i].id;
+            curAdType = adInfo[i].adType;
+            curUnit = {
+                code: curAdId,
+                mediaTypes: {
+                    banner: {
+                        sizes: amu_ads.adSlotConfig[curAdType].breakpoint.sizes
+                    }
+                },
+                bids: amu_ads.adSlotConfig[curAdType].breakpoint.bids
+            };
+            adUnits.push(curUnit);
+        }
+        return adUnits
+    };
+
+    var defineAds = function(adInfo) {
+        var slots = [];
+        var i, curSlot, curAdId, curAdType;
+        for (i = 0; i &lt; adInfo.length; i++) {
+            curAdId = adInfo[i].id;
+            curAdType = adInfo[i].adType;
+            // Define slot
+            curSlot = googletag.defineSlot(amu_ads.adSlotPath, amu_ads.adSlotConfig[curAdType].breakpoint.sizes, curAdId).addService(googletag.pubads());
+
+            // Set slot level targeting
+            for (key in amu_ads.adSlotConfig[curAdType].targeting) {
+                curSlot.setTargeting(key, amu_ads.adSlotConfig[curAdType].targeting[key]);
+            }
+
+            slots.push(curSlot);
+
+            // Store slot for later use (refreshing ads, etc)
+            amu_ads.adSlots[curAdId] = curSlot;
+
+        }
+        return slots;
+    };
+
+    var displayAds = function(adInfo) {
+        var curAdId;
+        if(adInfo.length === 0) {
+            googletag.display();
+        } else {
+            for(var i = 0; i &lt; adInfo.length; i++) {
+                curAdId = adInfo[i].id;
+                googletag.display(curAdId);
+            }
+        }
+    };
+
+    var refreshAds = function(adSlots) {
+        for(var i = 0; i &lt; adSlots.length; i++) {
+            adSlots[i].setTargeting('pv', getPageviewFromCookie());
+        }
+
+        if(adSlots.length === 0) {
+            googletag.pubads().refresh();
+        } else {
+            googletag.pubads().refresh(adSlots);
+        }
+    };
+
+    var auctionInit = function(adInfo, refresh) {
+        if(adInfo.length &gt; 0){
+            if(isEU) {
+                googletag.cmd.push(function() {
+                    // Define ads
+                    var adSlots = defineAds(adInfo);
+
+                    // Enable services for GPT
+                    googletag.enableServices();
+
+                    // Display Ads
+                    displayAds(adInfo);
+
+                    // Refresh bids
+                    refreshAds(adSlots);
+                });
+            } else {
+                pbjs.que.push(function() {
+                    googletag.cmd.push(function() {
+                        if(!refresh) {
+                            // Build ad units and add them to Prebid
+                            var adUnits = buildAdUnits(adInfo);
+                            pbjs.addAdUnits(adUnits);
+
+                            // Define ads
+                            var adSlots = defineAds(adInfo);
+
+                            // Enable services for GPT
+                            googletag.enableServices();
+                        } else {
+                            // Get existing ad slots
+                            var adSlots = adInfo.map(getAdSlot);
+                        }
+                        // Start header-bidding auction
+                        startAuction(1500, adInfo, adSlots, refresh);
+                    });
+                });
+            }
+        }
+    };
+
+    // Venatus
+    window.VM_API.push({
+        call: "is-consent-required",
+        onResult: function(res) {
+            //res = true in EU
+            //res = false outside EU
+            isEU = res;
+            if (document.readyState === "loading") {
+                document.addEventListener("DOMContentLoaded", function(event) {
+                    // Find ads
+                    var adElements = findAds('js-ad');
+
+                    // Get ad info
+                    var adInfo = getAdInfo(adElements);
+                    auctionInit(adInfo, false);
+
+                    //Lazy load ads
+                    adLazyLoaderInit('js-ad-lazy-load');
+
+                    // Refresh in view ads
+                    adRefresherInit('js-ad-refresh');
+                });
+            } else {
+                // Find ads
+                var adElements = findAds('js-ad');
+
+                // Get ad info
+                var adInfo = getAdInfo(adElements);
+
+                auctionInit(adInfo, false);
+
+                //Lazy load ads
+                adLazyLoaderInit('js-ad-lazy-load');
+
+                // Refresh ads in view
+                adRefresherInit('js-ad-refresh');
+            }
+        }
+    });
+
+&lt;/script&gt;
+
+
+&lt;!-- Sharethrough --&gt;
+&lt;script type="text/javascript" src="https://native.sharethrough.com/assets/sfp.js"&gt;&lt;/script&gt;
+
+    &lt;!-- Begin Monetate ExpressTag Sync v8.1. Place at start of document head. DO NOT ALTER. --&gt;
+&lt;script type="text/javascript"&gt;var monetateT = new Date().getTime();&lt;/script&gt;
+&lt;script type="text/javascript" src="//se.monetate.net/js/2/a-8760e223/p/gocomics.com/entry.js"&gt;&lt;/script&gt;
+&lt;!-- End Monetate tag --&gt;
+
+&lt;script type="text/javascript"&gt;
+    window.monetateQ = window.monetateQ || [];
+
+    // Set page type
+        window.monetateQ.push([
+        'setPageType',
+        'feature-item'
+    ]);
+
+    // Set custom variables
+    monetateQ.push([
+        'setCustomVariables',
+        [
+            // Feature variables
+            {
+                name: 'featureCode',
+                value: 'cw'
+            },
+
+            // Ad variables
+            {
+                name: 'advertisingChannel',
+                value: 'a'
+            },
+
+            // User variables
+        ]
+    ]);
+
+    // Call trackData when data is ready to be sent to Monetate.
+    // Each time trackData is called, monetateQ is cleared.
+    window.monetateQ.push([
+        "trackData"
+    ]);
+&lt;/script&gt;
+
+    &lt;!-- BEGIN GTM Core Data Layer --&gt;
+&lt;script&gt;
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+        'event': 'dataLayer-loaded',
+        'language': 'english',
+
+        'pageType': 'feature-item',
+
+
+
+        'featureName': '9 chickweed lane',
+        'featureCode': 'cw',
+        'featureType': 'comic',
+        'featureFormat': 'print',
+
+        'featureItemPublishDate': '2019-07-16',
+
+
+        'advertisingChannel': 'a',
+
+        // User variables
+
+        'visitType': 'new',
+
+        'loginStatus': 'logged out'
+    });
+&lt;/script&gt;
+&lt;!-- END GTM Core Data Layer --&gt;
+
+    &lt;!-- Google Tag Manager HEAD? --&gt;
+&lt;script&gt;(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&amp;l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-PN7JV4B');&lt;/script&gt;
+&lt;!-- End Google Tag Manager --&gt;
+
+    &lt;script type="text/javascript"&gt;
+//Set markup and styling here
+window.cookieconsent_options = {
+  container: '#cookieconsent-container',
+  learnMore: 'More info',
+  link: "//www.andrewsmcmeel.com/privacy-policy",
+  //If you wish to use your own CSS instead, specify the URL of your CSS file. e.g. styles/my_custom_theme.css.
+  //This can be a relative or absolute URL.
+  //To stop Cookie Consent from loading CSS at all, specify false
+  //IE8 Styles need to be duplicated in app specific css overrides /assets/stylesheets/ie/ie8.css
+  theme: false,
+  markup: [
+    '&lt;div&gt;',
+    '&lt;style type="text/css"&gt;.cc_banner-wrapper {height: 70px; } .cc_container {position:absolute; width:100%; left:0; top:80px; right:0; overflow:hidden; background-color:#666; } .cookie-choices-info {margin:0; padding:0; text-align:center; color:#fff; line-height:140%; padding:15px 0; font-family:roboto,Arial } .cookie-choices-info .cookie-choices-text {display:inline-block; vertical-align:middle; font-size:16px; margin:10px; color:#fefefe; max-width:800px; text-align:center } .cookie-choices-info .cookie-choices-buttons {display:inline-block; vertical-align:middle; white-space:nowrap; margin:10px } .cookie-choices-info .cookie-choices-button:hover {color:#fff; background-color:#000 } .cookie-choices-info .cookie-choices-button {background:#444; font-weight:700; text-transform:UPPERCASE; white-space:nowrap; color:#eee; margin-left:8px; padding:10px; border-radius:3px; text-decoration:none } @media screen and (max-width: 992px) {.cc_container {top: 60px}} @media screen and (max-width: 851px) {.cc_container {top: 60px} .cc_banner-wrapper {height:110px } } @media screen and (max-width: 588px) {.cc_banner-wrapper {height:140px} } @media screen and (max-width: 327px) {.cc_banner-wrapper {height:160px} } @media print {.cc_banner-wrapper,.cc_container {display:none } }&lt;/style&gt;',
+    '&lt;div class="cc_banner-wrapper {{containerClasses}}"&gt;',
+    '&lt;div class="cc_banner cc_container cc_container--open"&gt;',
+    '&lt;div class="cookie-choices-info"&gt;&lt;div class="cookie-choices-inner"&gt;&lt;span class="cookie-choices-text"&gt;{{options.message}}&lt;/span&gt;&lt;span class="cookie-choices-buttons"&gt; &lt;a data-cc-if="options.link" class="cookie-choices-button" target="_blank" href="{{options.link || "#null"}}"&gt;{{options.learnMore}}&lt;/a&gt; &lt;a id="cookieChoiceDismiss" href="#null" data-cc-event="click:dismiss"  class="cookie-choices-button"&gt;{{options.dismiss}}&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;&lt;/div&gt;',
+    '&lt;/div&gt;',
+    '&lt;/div&gt;',
+    '&lt;/div&gt;'
+  ],
+  cookieName: 'gocomics_cookieconsent_dismissed',
+  readystate: 'interactive'
+};
+&lt;/script&gt;
+
+    &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" integrity="sha384-acGNjq0ZO3YC8YdbDezfdh+P9JYzpbVLNKWULhNFraiKnRIhnbcb75B7Jvzqf3hA" crossorigin="anonymous"&gt;
+  &lt;/head&gt;
+  &lt;body role="document" data-controller="feature_items" data-action="feature-lander" class="js-gc-page-item gc-page-item gc-profile-casual 9chickweedlane"&gt;
+
+    &lt;!-- All Server-Side Analytic Values or Markup (No Script Calls or Heavy Client-Side Scripting) --&gt;
+
+&lt;!-- Google Tag Manager (noscript) --&gt;
+&lt;noscript&gt;&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PN7JV4B" height="0" width="0" style="display:none;visibility:hidden"&gt;&lt;/iframe&gt;&lt;/noscript&gt;
+&lt;!-- End Google Tag Manager (noscript) --&gt;
+
+
+
+
+
+
+
+
+
+
+
+
+
+&lt;!-- TEST:  --&gt;
+
+
+
+
+&lt;script type="text/javascript"&gt;
+    amuGc.env = "production";
+    amuGc.displayAds = true;
+    amuGc.uaCategoryGroup = 'comic strips';
+    amuGc.uaSubcategoryGroup = '';
+    amuGc.uaTypeGroup = 'print';
+    amuGc.uaClientName = "gocomics";
+    amuGc.uaFeatureName = '9 chickweed lane';
+    amuGc.uaUserType = 'casual';
+    amuGc.uaUserId = '';
+    amuGc.uaUserPromo = '';
+    amuGc.qcLabel = 'comic.9chickweedlane'
+&lt;/script&gt;
+&lt;!-- Google Universal Analytics End --&gt;
+
+    &lt;div class="js-amu-container-global"&gt;
+      &lt;!-- Start Site Header --&gt;
+&lt;div class="gc-site-header js-navbar"&gt;
+  &lt;header class="gc-content__1col gc-gap-none"&gt;
+
+    &lt;nav class='navbar navbar-expand-lg navbar-light bg-white gc-nav-primary container'&gt;
+
+      &lt;button class='navbar-toggler collapsed gc-hamburger' type='button' data-toggle='collapse' data-target='.gc-nav-primary__left-menu' aria-controls='gc-nav-primary__left-menu' aria-expanded='false' aria-label='Toggle navigation'&gt;
+
+        &lt;div class='gc-hamburger__icon'&gt;
+          &lt;span&gt;&lt;/span&gt;
+          &lt;span&gt;&lt;/span&gt;
+          &lt;span&gt;&lt;/span&gt;
+        &lt;/div&gt;
+
+      &lt;/button&gt;
+
+      &lt;a title="GoComics Home" class="navbar-brand gc-logo" data-link-type="header-nav-tier-1" href="https://www.gocomics.com/"&gt;
+        &lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  --&gt;
+&lt;svg version="1.1" class="gc-logo__default" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewbox="161 314.5 934.6 165.5" style="enable-background:new 161 314.5 934.6 165.5;" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"&gt;
+	&lt;path d="M437.5,456.8h-23.6v-7.2c-6.3,5.1-16.6,9.3-30.5,9.3c-37.2,0-62.8-25.4-62.8-63.3c0-34.7,25-63.1,62.8-63.1
+		c25.7,0,41.6,11.1,50.1,24.2l-19,14.1c-5.6-7.6-14.8-15.5-31-15.5c-22,0-37.2,16.6-37.2,40.4c0,24.7,16.2,40.7,38.3,40.7
+		c14.1,0,24-5.5,29.1-10.8v-13.9h-19.9v-20.5h43.9v65.6H437.5z"&gt;&lt;/path&gt;
+	&lt;path class="g-path" d="M497,360.9c29.8,0,49.4,20.8,49.4,48.7c0,27.7-20.3,48.8-49.4,48.8c-29.4,0-49.2-20.6-49.2-48.5
+		C447.8,381.9,468.7,360.9,497,360.9z M497.2,437.1c15.5,0,25.6-11.6,25.6-27.3c0-15.7-10.6-27.5-25.8-27.5
+		c-15.5,0-25.6,11.6-25.6,27.5C471.5,425.6,482.1,437.1,497.2,437.1z"&gt;&lt;/path&gt;
+	&lt;path class="o-path" d="M659.8,443.1c-9.3,9.2-22.7,16-40.4,16c-39.3,0-64-27.2-64-63.1c0-35.8,25.4-63.5,63.5-63.5c17.5,0,30.9,5.6,40.6,14.3
+		L645,365.2c-5.6-4.9-14.6-9.9-25.9-9.9c-23.6,0-37.9,17.6-37.9,40.6c0,23.1,15.3,40.4,38.3,40.4c12.3,0,21-5.8,26.1-10.2
+		L659.8,443.1z"&gt;&lt;/path&gt;
+	&lt;path class="c-path" d="M708,360.9c29.8,0,49.4,20.8,49.4,48.7c0,27.7-20.3,48.8-49.4,48.8c-29.4,0-49.2-20.6-49.2-48.5
+		C658.8,381.9,679.6,360.9,708,360.9z M708.2,437.1c15.5,0,25.6-11.6,25.6-27.3c0-15.7-10.6-27.5-25.8-27.5
+		c-15.5,0-25.6,11.6-25.6,27.5C682.4,425.6,693,437.1,708.2,437.1z"&gt;&lt;/path&gt;
+	&lt;path class="o-path" d="M839.9,456.8h-23.6v-59.4c0-9-4.2-15-12.5-15c-8.5,0-12.9,6-12.9,15.3v59.1h-23.6v-94.3h23.6v7.1c2.5-3,8.3-8.1,20.3-8.1
+		c11.1,0,18.2,4.2,22.4,10.2c4.2-4.9,11.3-10.2,23.6-10.2c23.3,0,31.7,15,31.7,33.1v62.2h-23.6v-59.4c0-9.2-4.2-15-12.7-15
+		s-12.7,6.5-12.7,15V456.8z"&gt;&lt;/path&gt;
+	&lt;path class="m-path" d="M902.8,342.6c0-7.9,6.3-14.3,14.1-14.3c7.9,0,14.1,6.3,14.1,14.3c0,7.8-6.2,13.9-14.1,13.9
+		C909.2,356.5,902.8,350.3,902.8,342.6z M928.8,456.8h-23.6v-94.3h23.6V456.8z"&gt;&lt;/path&gt;
+	&lt;path class="i-path" d="M1009.3,429.3l13,15.9c-5.6,6-16.8,13.2-33,13.2c-29.8,0-48.8-21.2-48.8-48.5c0-27.5,20.5-49,48.7-49
+		c17.1,0,27.5,6.9,33.2,12.7l-13.6,16.4c-3.9-3.7-10.1-7.8-19.4-7.8c-15.5,0-25.2,11.8-25.2,27.5c0,16.9,11.8,27.3,25.4,27.3
+		C999.1,437.1,1005.1,432.9,1009.3,429.3z"&gt;&lt;/path&gt;
+	&lt;path class="c2-path" d="M1060.1,396.4c4.2,1.2,8.1,1.9,12.9,3.4c15.2,4.6,22.6,12,22.6,29.1c0,19.2-15.9,29.3-34.4,29.3
+		c-26.1,0-34.2-15.3-33.7-31.7h22.6c0,6.7,2.3,12.7,11.5,12.7c6.2,0,11.1-3,11.1-8.5s-2.8-7.9-9.3-9.7c-5.1-1.4-9.2-2.3-14.3-4.2
+		c-13-4.8-19.6-13.6-19.6-27.9c0-15.9,13.4-27.5,32.3-27.5c19.9,0,31.7,10.1,31.9,29.8H1072c-0.2-7.2-3.5-11.5-10.8-11.5
+		c-5.6,0-9.3,3.2-9.3,7.9C1051.8,392.1,1054.5,394.8,1060.1,396.4z"&gt;&lt;/path&gt;
+	&lt;path class="s-path" d="M161,314.5v95c0,43.5,26.5,70.5,69.1,70.5c41.5,0,69.5-28.4,69.5-70.7v-94.8H161z M244.2,351c5.6,0,10.1,4.5,10.1,10.1
+		s-4.5,10.1-10.1,10.1s-10.1-4.5-10.1-10.1C234.2,355.5,238.7,351,244.2,351z M213.9,352.9c4.5,0,8.1,3.6,8.1,8.1s-3.6,8.1-8.1,8.1
+		s-8.1-3.6-8.1-8.1C205.8,356.6,209.4,352.9,213.9,352.9z M278.9,409.3c0,28.9-16.9,50.1-48.8,50.1c-33.1,0-48.5-19.9-48.5-49.9
+		v-57.2h11.1v57.2c0,12.6,3,22.2,8.9,28.7c6.1,6.7,15.7,10.1,28.5,10.1c24,0,37.8-14.2,37.8-39v-74.2H279v74.2H278.9z"&gt;&lt;/path&gt;
+&lt;/svg&gt;
+
+        &lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  --&gt;
+&lt;svg version="1.1" class="gc-logo__wink" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewbox="161 314.5 934.6 165.5" style="enable-background:new 161 314.5 934.6 165.5;" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"&gt;
+	&lt;path class="face-path" d="M437.5,456.8h-23.6v-7.2c-6.3,5.1-16.6,9.3-30.5,9.3c-37.2,0-62.8-25.4-62.8-63.3c0-34.7,25-63.1,62.8-63.1
+		c25.7,0,41.6,11.1,50.1,24.2l-19,14.1c-5.6-7.6-14.8-15.5-31-15.5c-22,0-37.2,16.6-37.2,40.4c0,24.7,16.2,40.7,38.3,40.7
+		c14.1,0,24-5.5,29.1-10.8v-13.9h-19.9v-20.5h43.9v65.6H437.5z"&gt;&lt;/path&gt;
+	&lt;path class="g-path" d="M497,360.9c29.8,0,49.4,20.8,49.4,48.7c0,27.7-20.3,48.8-49.4,48.8c-29.4,0-49.2-20.6-49.2-48.5
+		C447.8,381.9,468.7,360.9,497,360.9z M497.2,437.1c15.5,0,25.6-11.6,25.6-27.3c0-15.7-10.6-27.5-25.8-27.5
+		c-15.5,0-25.6,11.6-25.6,27.5C471.5,425.6,482.1,437.1,497.2,437.1z"&gt;&lt;/path&gt;
+	&lt;path class="o-path" d="M659.8,443.1c-9.3,9.2-22.7,16-40.4,16c-39.3,0-64-27.2-64-63.1c0-35.8,25.4-63.5,63.5-63.5c17.5,0,30.9,5.6,40.6,14.3
+		L645,365.2c-5.6-4.9-14.6-9.9-25.9-9.9c-23.6,0-37.9,17.6-37.9,40.6c0,23.1,15.3,40.4,38.3,40.4c12.3,0,21-5.8,26.1-10.2
+		L659.8,443.1z"&gt;&lt;/path&gt;
+	&lt;path class="c-path" d="M708,360.9c29.8,0,49.4,20.8,49.4,48.7c0,27.7-20.3,48.8-49.4,48.8c-29.4,0-49.2-20.6-49.2-48.5
+		C658.8,381.9,679.6,360.9,708,360.9z M708.2,437.1c15.5,0,25.6-11.6,25.6-27.3c0-15.7-10.6-27.5-25.8-27.5
+		c-15.5,0-25.6,11.6-25.6,27.5C682.4,425.6,693,437.1,708.2,437.1z"&gt;&lt;/path&gt;
+	&lt;path class="o2-path" d="M839.9,456.8h-23.6v-59.4c0-9-4.2-15-12.5-15c-8.5,0-12.9,6-12.9,15.3v59.1h-23.6v-94.3h23.6v7.1c2.5-3,8.3-8.1,20.3-8.1
+		c11.1,0,18.2,4.2,22.4,10.2c4.2-4.9,11.3-10.2,23.6-10.2c23.3,0,31.7,15,31.7,33.1v62.2h-23.6v-59.4c0-9.2-4.2-15-12.7-15
+		s-12.7,6.5-12.7,15V456.8z"&gt;&lt;/path&gt;
+	&lt;path class="m-path" d="M902.8,342.6c0-7.9,6.3-14.3,14.1-14.3c7.9,0,14.1,6.3,14.1,14.3c0,7.8-6.2,13.9-14.1,13.9
+		C909.2,356.5,902.8,350.3,902.8,342.6z M928.8,456.8h-23.6v-94.3h23.6V456.8z"&gt;&lt;/path&gt;
+	&lt;path class="i-path" d="M1009.3,429.3l13,15.9c-5.6,6-16.8,13.2-33,13.2c-29.8,0-48.8-21.2-48.8-48.5c0-27.5,20.5-49,48.7-49
+		c17.1,0,27.5,6.9,33.2,12.7l-13.6,16.4c-3.9-3.7-10.1-7.8-19.4-7.8c-15.5,0-25.2,11.8-25.2,27.5c0,16.9,11.8,27.3,25.4,27.3
+		C999.1,437.1,1005.1,432.9,1009.3,429.3z"&gt;&lt;/path&gt;
+	&lt;path class="c-path" d="M1060.1,396.4c4.2,1.2,8.1,1.9,12.9,3.4c15.2,4.6,22.6,12,22.6,29.1c0,19.2-15.9,29.3-34.4,29.3
+		c-26.1,0-34.2-15.3-33.7-31.7h22.6c0,6.7,2.3,12.7,11.5,12.7c6.2,0,11.1-3,11.1-8.5s-2.8-7.9-9.3-9.7c-5.1-1.4-9.2-2.3-14.3-4.2
+		c-13-4.8-19.6-13.6-19.6-27.9c0-15.9,13.4-27.5,32.3-27.5c19.9,0,31.7,10.1,31.9,29.8H1072c-0.2-7.2-3.5-11.5-10.8-11.5
+		c-5.6,0-9.3,3.2-9.3,7.9C1051.8,392.1,1054.5,394.8,1060.1,396.4z"&gt;&lt;/path&gt;
+	&lt;path class="s-path" d="M161,314.5v95c0,43.5,26.5,70.5,69.1,70.5c41.5,0,69.5-28.4,69.5-70.7v-94.8H161z M213.9,352.9c4.5,0,8.1,3.6,8.1,8.1
+		s-3.6,8.1-8.1,8.1s-8.1-3.6-8.1-8.1C205.8,356.6,209.4,352.9,213.9,352.9z M278.9,409.3c0,28.9-16.9,50.1-48.8,50.1
+		c-33.1,0-48.5-19.9-48.5-49.9v-57.2h11.1v57.2c0,12.6,3,22.2,8.9,28.7c6.1,6.7,15.7,10.1,28.5,10.1c24,0,37.8-14.2,37.8-39v-74.2
+		H279v74.2H278.9z"&gt;&lt;/path&gt;
+	&lt;g&gt;
+		&lt;g&gt;
+			&lt;path style="fill:#FFFFFF;" d="M250.4,366.3c-0.1,0-0.2,0-0.4,0c-4.3-0.6-8.7-1-13.1-1.1c-0.9,0-1.8-0.5-2.2-1.4
+				c-0.4-0.8-0.4-1.8,0.1-2.6c4.3-6.5,12.2-10.6,20-10.3c1.4,0,2.5,1.2,2.5,2.6c0,1.4-1.2,2.5-2.6,2.5c-4.4-0.1-8.9,1.5-12.3,4.4
+				c2.8,0.2,5.6,0.5,8.4,0.9c1.4,0.2,2.3,1.5,2.1,2.9C252.7,365.4,251.6,366.3,250.4,366.3z"&gt;&lt;/path&gt;
+		&lt;/g&gt;
+	&lt;/g&gt;
+&lt;/svg&gt;
+
+&lt;/a&gt;
+      &lt;button class='navbar-toggler collapsed gc-search js-gc-search-focus' type='button' data-toggle='collapse' data-target='.gc-nav-primary__search--mobile' aria-controls='gc-nav-primary__search' aria-expanded='false' aria-label='Toggle navigation'&gt;
+
+        &lt;div class='gc-search__icon'&gt;
+          &lt;span&gt;&lt;/span&gt;
+          &lt;span&gt;&lt;/span&gt;
+          &lt;span&gt;&lt;/span&gt;
+        &lt;/div&gt;
+
+      &lt;/button&gt;
+
+      &lt;div class="collapse navbar-collapse bg-white gc-nav-primary__search gc-nav-primary__search--mobile js-mobile-nav"&gt;
+        &lt;form class="gc-search-form js-search-form" role="search" autocomplete="off" action="/search/9chickweedlane" accept-charset="UTF-8" method="get"&gt;&lt;input name="utf8" type="hidden" value="&amp;#x2713;" /&gt;
+  &lt;fieldset class='form-group m-0'&gt;
+    &lt;legend class='sr-only'&gt;GoComics.com - Search Form&lt;/legend&gt;
+    &lt;label class="sr-only" for="search_terms"&gt;Search&lt;/label&gt;
+    &lt;div class='input-group'&gt;
+      &lt;input type="search" name="terms" id="terms" class="form-control gc-search-form__input" placeholder="Search for Your Favorite Comic..." required="required" tabindex="-1" maxlength="50" minlength="1" /&gt;
+      &lt;div class="input-group-append"&gt;
+        &lt;button name="button" type="submit" class="btn btn-sm input-group-text gc-search-form__submit js-search-button" aria-label="Submit Search"&gt;
+          &lt;i class="fa fa-search"&gt;&lt;/i&gt;
+&lt;/button&gt;      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/fieldset&gt;
+&lt;/form&gt;
+      &lt;/div&gt;
+
+
+
+      &lt;div class='collapse navbar-collapse bg-white gc-nav-primary__left-menu js-mobile-nav'&gt;
+        &lt;ul class='navbar-nav'&gt;
+
+          &lt;li class="nav-item dropdown gc-nav-primary__item"&gt;&lt;a class="nav-link dropdown-toggle  gc-nav-primary__link" role="button" aria-haspopup="true" aria-expanded="false" data-link-type="banner-nav-tier-1" data-toggle="dropdown" href="https://www.gocomics.com/comics"&gt;Find Comics&lt;/a&gt;&lt;div class="dropdown-menu rounded-0  gc-nav-primary__dropdown-menu "&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/trending"&gt;Trending Comics&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/political"&gt;Political Cartoons&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/web-comics"&gt;Web Comics&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/categories"&gt;All Categories&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/popular"&gt;Popular Comics&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/a-to-z"&gt;A-Z Comics by Title&lt;/a&gt;
+&lt;/div&gt;&lt;/li&gt;
+
+
+          &lt;li class="nav-item dropdown gc-nav-primary__item"&gt;&lt;a class="nav-link dropdown-toggle  gc-nav-primary__link" role="button" aria-haspopup="true" aria-expanded="false" data-link-type="banner-nav-tier-1" data-toggle="dropdown" href="#"&gt;Best Of&lt;/a&gt;&lt;div class="dropdown-menu rounded-0  gc-nav-primary__dropdown-menu "&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/recommended"&gt;Recommended Comics&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/collections"&gt;Comic Lists&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/blog"&gt;Blog&lt;/a&gt;
+&lt;/div&gt;&lt;/li&gt;
+
+
+            &lt;li class="nav-item dropdown gc-nav-primary__item"&gt;&lt;a class="nav-link dropdown-toggle  gc-nav-primary__link" role="button" aria-haspopup="true" aria-expanded="false" data-link-type="banner-nav-tier-1" data-toggle="dropdown" href="https://store.gocomics.com/"&gt;Shop&lt;/a&gt;&lt;div class="dropdown-menu rounded-0  gc-nav-primary__dropdown-menu "&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/"&gt;Home&lt;/a&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/product-category/books/"&gt;Books&lt;/a&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/product-category/calendars/"&gt;Calendars&lt;/a&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/product-category/popular-print/"&gt;Comic Prints&lt;/a&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/cart/"&gt;Your Cart&lt;/a&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/checkout/"&gt;Checkout&lt;/a&gt;
+&lt;/div&gt;&lt;/li&gt;
+
+
+          &lt;div class="gc-nav-primary__search gc-nav-primary__item--desktop-only"&gt;
+            &lt;form class="gc-search-form js-search-form" role="search" autocomplete="off" action="/search/9chickweedlane" accept-charset="UTF-8" method="get"&gt;&lt;input name="utf8" type="hidden" value="&amp;#x2713;" /&gt;
+  &lt;fieldset class='form-group m-0'&gt;
+    &lt;legend class='sr-only'&gt;GoComics.com - Search Form&lt;/legend&gt;
+    &lt;label class="sr-only" for="search_terms"&gt;Search&lt;/label&gt;
+    &lt;div class='input-group'&gt;
+      &lt;input type="search" name="terms" id="terms" class="form-control gc-search-form__input" placeholder="Search for Your Favorite Comic..." required="required" tabindex="-1" maxlength="50" minlength="1" /&gt;
+      &lt;div class="input-group-append"&gt;
+        &lt;button name="button" type="submit" class="btn btn-sm input-group-text gc-search-form__submit js-search-button" aria-label="Submit Search"&gt;
+          &lt;i class="fa fa-search"&gt;&lt;/i&gt;
+&lt;/button&gt;      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/fieldset&gt;
+&lt;/form&gt;
+          &lt;/div&gt;
+
+
+
+
+            &lt;div class="gc-nav-primary__authentication"&gt;
+              &lt;li class="nav-item gc-nav-primary__item"&gt;&lt;a rel="nofollow" class="nav-link  gc-nav-primary__link" data-link-type="header-nav-tier-1" href="https://www.gocomics.com/profiles/sign-in"&gt;Sign In&lt;/a&gt;&lt;/li&gt;
+              &lt;li class="nav-item gc-nav-primary__item"&gt;&lt;a rel="nofollow" class="nav-link  gc-nav-primary__link" data-link-type="header-nav-tier-1" href="https://www.gocomics.com/help/why-upgrade-to-premium-ad-free-subscription"&gt;Free Trial&lt;/a&gt;&lt;/li&gt;
+            &lt;/div&gt;
+        &lt;/ul&gt;
+      &lt;/div&gt;
+
+    &lt;/nav&gt;
+
+  &lt;/header&gt;
+&lt;/div&gt;&lt;!-- End Site Header --&gt;
+
+      &lt;div id='cookieconsent-container'&gt;&lt;/div&gt;
+
+
+      &lt;noscript&gt;
+        &lt;div class="amu-container-layout gc-no-js"&gt;
+          
+&lt;div class='amu-container-alert'&gt;
+  &lt;div class="alert alert-dismissible fade show gc-alert gc-alert--error js-gc-alert" role="alert"&gt;
+    &lt;strong&gt;Oh snap!&lt;/strong&gt; GoComics needs JavaScript to work, please enable JavaScript in your browser settings.
+    &lt;button type="button" class="close js-gc-alert-close" data-dismiss="alert" aria-label="Close"&gt;
+      &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
+    &lt;/button&gt;
+&lt;/div&gt;&lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/noscript&gt;
+
+      &lt;div role="main" class="gc-page-container"&gt;
+
+
+
+        
+
+  
+
+  &lt;div class='gc-container gc-container--fluid'&gt;
+    &lt;div class='layout-2col layout-2col--comic'&gt;
+
+      &lt;div class="layout-2col-sidebar bg-white border-right js-gc-lock-parent hidden-md-down"&gt;
+        &lt;aside class="gc-feature-side"&gt;
+  &lt;div class="gc-fade-bottom"&gt;
+    &lt;picture class="card-img lazyload__padder lazyload__padder--card"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://avatar.amuniversal.com/feature_avatars/recommendation_images/features/cw/large_rec-201701251556.jpg 600w, https://avatar.amuniversal.com/feature_avatars/recommendation_images/features/cw/mid_rec-201701251556.jpg 300w, https://avatar.amuniversal.com/feature_avatars/recommendation_images/features/cw/small_rec-201701251556.jpg 150w" sizes="auto" width="100%" alt="#&amp;lt;Feature:0x00007f65f0f5d1f8&amp;gt;" src="https://avatar.amuniversal.com/feature_avatars/recommendation_images/features/cw/large_rec-201701251556.jpg" /&gt;&lt;/picture&gt;
+  &lt;/div&gt;
+  &lt;div class="gc-feature-side__info"&gt;
+    &lt;a class="gc-blended-link gc-blended-link--primary" href="/9chickweedlane"&gt;
+      
+
+
+&lt;div class='media amu-media-item'&gt;
+  &lt;div class='media-left'&gt;
+    &lt;div class="gc-avatar gc-avatar--creator xs"&gt;&lt;img srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/small_u-201701251613.png, 72w" class="lazyload" alt="9 Chickweed Lane" src="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/small_u-201701251613.png" /&gt;&lt;/div&gt;
+  &lt;/div&gt;
+  &lt;div class='media-body ml-3'&gt;
+    &lt;h2 class='media-heading h4 mb-0'&gt;9 Chickweed Lane&lt;/h2&gt;
+    &lt;span class="media-subheading small"&gt;By Brooke McEldowney&lt;/span&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;/a&gt;    &lt;div class="gc-feature-side__follow js-subscription-feature-358"&gt;
+    &lt;a class="btn btn-primary btn-block" data-toggle="modal" data-tooltip="tooltip" data-target="#js-modal-account-hook" data-modal-message="Sign up or sign in to add comics to your comics page." aria-label="Sign up or sign in to add 9 Chickweed Lane to your Comics I Follow" title="Sign up or sign in to add 9 Chickweed Lane to your Comics I Follow" rel="nofollow" href=""&gt;
+      Follow
+&lt;/a&gt;&lt;/div&gt;
+
+  &lt;/div&gt;
+&lt;/aside&gt;
+          &lt;div class='js-gc-lock-target'&gt;
+            
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-tower_nav-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="tower_nav" class="js-ad js-ad-refresh gc-ad ad-tower_nav" data-ad-type="tower_nav"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+          &lt;/div&gt;
+      &lt;/div&gt;
+
+      &lt;div class="layout-2col-content content-section-padded"&gt;
+
+        &lt;div class="gc-feature-header"&gt;
+  &lt;div class="gc-feature-header__info"&gt;
+    &lt;!-- Media Object --&gt;
+    &lt;a class="gc-blended-link gc-blended-link--primary" href="/9chickweedlane"&gt;
+      
+
+
+&lt;div class='media amu-media-item'&gt;
+  &lt;div class='media-left'&gt;
+    &lt;div class="gc-avatar gc-avatar--creator xs"&gt;&lt;img srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/small_u-201701251613.png, 72w" class="lazyload" alt="9 Chickweed Lane" src="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/small_u-201701251613.png" /&gt;&lt;/div&gt;
+  &lt;/div&gt;
+  &lt;div class='media-body ml-3'&gt;
+    &lt;h4 class='media-heading h4 mb-0'&gt;9 Chickweed Lane&lt;/h4&gt;
+    &lt;span class="media-subheading small"&gt;By Brooke McEldowney&lt;/span&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;/a&gt;    &lt;!-- Follow Button --&gt;
+    &lt;div class="gc-feature-side__follow js-subscription-feature-358"&gt;
+    &lt;a class="btn btn-primary btn-block" data-toggle="modal" data-tooltip="tooltip" data-target="#js-modal-account-hook" data-modal-message="Sign up or sign in to add comics to your comics page." aria-label="Sign up or sign in to add 9 Chickweed Lane to your Comics I Follow" title="Sign up or sign in to add 9 Chickweed Lane to your Comics I Follow" rel="nofollow" href=""&gt;
+      Follow
+&lt;/a&gt;&lt;/div&gt;
+
+  &lt;/div&gt;
+&lt;/div&gt;
+
+        
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-leaderboard_feature_item-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="leaderboard_feature_item" class="js-ad js-ad-refresh gc-ad ad-leaderboard_feature_item" data-ad-type="leaderboard_feature_item"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+        &lt;nav class='content-section-padded-sm'&gt;
+  &lt;ul class='nav nav-tabs gc-tab-nav js-tab-nav' style="visibility: hidden;"&gt;
+    &lt;li class="nav-item"&gt;&lt;a class="nav-link " data-link="overview" href="/9chickweedlane"&gt;Overview&lt;/a&gt;&lt;/li&gt;
+    &lt;li class="nav-item"&gt;&lt;a class="nav-link active" data-link="comics" href="/9chickweedlane/2019/07/16"&gt;Comics&lt;/a&gt;&lt;/li&gt;
+    &lt;li class="nav-item"&gt;&lt;a class="nav-link " data-link="about" href="/9chickweedlane/about"&gt;About&lt;/a&gt;&lt;/li&gt;
+    
+  &lt;/ul&gt;
+&lt;/nav&gt;
+
+
+
+        
+  &lt;div class="gc-container"&gt;
+    &lt;h1 class="m-0 h6 text-center"&gt;9 Chickweed Lane by Brooke McEldowney for July 16, 2019&lt;/h1&gt;
+    
+
+
+&lt;div class="comic container js-comic-2770123 js-item-init js-item-share js-comic-swipe bg-white border rounded" data-shareable-model="FeatureItem"
+data-shareable-id="2770123"
+data-transcript=""
+data-id="2770123"
+data-feature-id="358"
+data-feature-name="9 Chickweed Lane"
+data-feature-code="cw"
+data-feature-type="comic"
+data-feature-format="print"
+data-date="2019-07-16"
+data-formatted-date="July 16, 2019"
+data-url="https://www.gocomics.com/9chickweedlane/2019/07/16"
+data-creator="Brooke McEldowney"
+data-title="9 Chickweed Lane for July 16, 2019 | GoComics.com"
+data-tags=""
+data-description="For July 16, 2019"
+data-image="https://assets.amuniversal.com/d4571e307e420137a88c005056a9545d"
+itemtype="http://schema.org/CreativeWork"
+accountableperson="Andrews McMeel Universal"
+creator="Brooke McEldowney"&gt;
+
+  &lt;div class='comic__wrapper'&gt;
+
+    
+
+    
+
+    &lt;div class='comic__container'&gt;
+
+
+      &lt;div class="comic__image js-comic-swipe-target"&gt;
+        &lt;div class="swipe-preview swipe-preview__previous js-preview-previous"&gt;
+  &lt;div class='swipe-preview__group'&gt;
+    &lt;h5 class='card-subtitle'&gt;
+        &lt;date&gt;July 15, 2019&lt;/date&gt;
+    &lt;/h5&gt;
+    &lt;div class='swipe-preview__ubadge'&gt;
+      &lt;div class="gc-avatar gc-avatar--creator sm"&gt;&lt;img srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/mid_u-201701251613.png, 137w" class="lazyload" alt="9 Chickweed Lane" src="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/mid_u-201701251613.png" /&gt;&lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+        &lt;a itemprop='image' class="js-item-comic-link" href="/9chickweedlane/2019/07/16" title="9 Chickweed Lane"&gt;
+
+  &lt;picture class="item-comic-image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://assets.amuniversal.com/d4571e307e420137a88c005056a9545d 900w" sizes="
+                       (min-width: 992px) 900px,
+                       (min-width: 768px) 600px,
+                       (min-width: 576px) 300px,
+                       900px" width="100%" alt="9 Chickweed Lane Comic Strip for July 16, 2019 " src="https://assets.amuniversal.com/d4571e307e420137a88c005056a9545d" /&gt;&lt;/picture&gt;
+&lt;/a&gt;
+&lt;meta itemprop='isFamilyFriendly' content='true'&gt;
+        &lt;div class="swipe-preview swipe-preview__next js-preview-next"&gt;
+  &lt;div class='swipe-preview__group'&gt;
+    &lt;h5 class='card-subtitle'&gt;
+        All caught up!
+    &lt;/h5&gt;
+    &lt;div class='swipe-preview__ubadge'&gt;
+      &lt;div class="gc-avatar gc-avatar--creator sm"&gt;&lt;img srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/mid_u-201701251613.png, 137w" class="lazyload" alt="9 Chickweed Lane" src="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/mid_u-201701251613.png" /&gt;&lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+      &lt;/div&gt;
+
+        &lt;nav class="gc-calendar-nav" role="group" aria-label="Date Navigation Controls"&gt;
+    &lt;div class="gc-calendar-nav__previous"&gt;
+      &lt;a role='button' href='/9chickweedlane/1993/07/12' class='fa btn btn-outline-secondary btn-circle fa fa-backward sm ' title='' &gt;&lt;/a&gt;
+      &lt;a role='button' href='/9chickweedlane/2019/07/15' class='fa btn btn-outline-secondary btn-circle fa-caret-left sm js-previous-comic ' title='' &gt;&lt;/a&gt;
+    &lt;/div&gt;
+    &lt;div class="gc-calendar-nav__select"&gt;
+      &lt;div class="btn btn-outline-secondary gc-calendar-nav__datepicker js-calendar-wrapper"
+           data-date="2019/07/16"
+           data-name="/9chickweedlane/"
+           data-year="2019"
+           data-month="07"
+           data-day="16"
+           data-feature="9chickweedlane"
+           data-ct=""
+           data-start="1993/07/12"
+           data-end="2019/07/16"
+           data-open="2019-07-16"&gt;
+          &lt;i class="fa fa-calendar xs"&gt;&lt;/i&gt;
+          &lt;input type="text" name="startDate" placeholder="July 16, 2019" readonly="readonly" class="cal off calendar-input date js-calendar-input datepicker js-calendar-input-link"&gt;
+      &lt;/div&gt;
+      &lt;a class="btn btn-outline-secondary" alt="Click to View a Random 9 Chickweed Lane Comic Strip!" href="/random/9chickweedlane"&gt;Random&lt;/a&gt;
+    &lt;/div&gt;
+    &lt;div class="gc-calendar-nav__next"&gt;
+      &lt;a role='button' href='' class='fa btn btn-outline-secondary btn-circle fa-caret-right sm disabled' title='' &gt;&lt;/a&gt;
+      &lt;a role='button' href='' class='fa btn btn-outline-secondary btn-circle fa-forward sm disabled' title='' &gt;&lt;/a&gt;
+    &lt;/div&gt;
+&lt;/nav&gt;
+
+
+    &lt;/div&gt;
+
+      &lt;div class="comic__interactions-container js-gc-lock-parent js-item-interactions-container "&gt;
+        &lt;div class="item-interactions js-gc-lock-target js-share-button-container dropdown" id="toolbar_2770123" data-gc-lock-depends="leaderboard_feature_item"&gt;
+  
+  &lt;div class='js-like'&gt;
+    &lt;a class="gc-icon fa fa-heart md" data-toggle="modal" data-target="#js-modal-account-hook" aria-label="Sign in to like this comic." title="Sign in to like this comic." data-tooltip="tooltip" rel="nofollow" href=""&gt;&lt;/a&gt;
+
+  &lt;span id="interaction_count_likes_2770123"  class="js-interaction-count h6 text-center interaction-count likes"&gt;125&lt;/span&gt;
+&lt;/div&gt;
+  &lt;div class=" js-favorite"&gt;
+    &lt;a class="gc-icon fa fa-thumb-tack md" data-toggle="modal" data-target="#js-modal-account-hook" data-modal-message="Sign up or sign in to add this to your Saved Comic Strips." title="Sign up or sign in to add to your Saved Comic Strips" data-tooltip="tooltip" rel="nofollow" href="#"&gt;&lt;/a&gt;
+  &lt;span id="interaction_count_favorites_2770123"  class="js-interaction-count h6 text-center interaction-count favorites"&gt;8&lt;/span&gt;
+&lt;/div&gt;
+  
+&lt;a class="js-facebook js-share-button gc-icon fa btn fa-facebook md" aria-label="Share on Facebook" data-tooltip="tooltip" title="Share on Facebook" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+&lt;a class="js-twitter js-share-button gc-icon fa btn fa-twitter md" aria-label="Share on Twitter" data-tooltip="tooltip" title="Share on Twitter" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+
+&lt;a role='button' href class='gc-icon fa fa-ellipsis-h md' data-toggle='dropdown' aria-label='More sharing options' data-tooltip='tooltip' title="More Sharing Options"&gt;&lt;/a&gt;
+
+&lt;div class='gc-share__dropdown dropdown-menu dropdown-menu-right'&gt;
+  &lt;div class='gc-share__social-links'&gt;
+    &lt;a class="js-reddit js-share-button gc-icon fa btn fa-reddit md" aria-label="Share on Reddit" data-tooltip="tooltip" title="Share on Reddit" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+    &lt;a class="js-google-plus js-share-button gc-icon fa btn fa-google-plus md" aria-label="Share on Google Plus" data-tooltip="tooltip" title="Share on Google Plus" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+    &lt;a class="js-tumblr js-share-button gc-icon fa btn fa-tumblr md" aria-label="Share on Tumblr" data-tooltip="tooltip" title="Share on Tumblr" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+    &lt;a class="js-pinterest js-share-button gc-icon fa btn fa-pinterest md" aria-label="Share on Pinterest" data-tooltip="tooltip" title="Share on Pinterest" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+
+    &lt;a aria-label="Share via email" title="Share via email" data-tooltip="tooltip" class="js-email js-share-button gc-icon fa btn fa-envelope md" href="mailto:?body=https%3A%2F%2Fwww.gocomics.com%2F9chickweedlane%2F2019%2F07%2F16&amp;amp;subject=Read%209%20Chickweed%20Lane%20by%20Brooke%20McEldowney%20on%20GoComics.com%20%7C%20July%2016%2C%202019"&gt;
+&lt;/a&gt;  &lt;/div&gt;
+
+  &lt;form class='text-center'&gt;
+    &lt;fieldset&gt;
+      &lt;legend class="sr-only"&gt;Share this - Copy link&lt;/legend&gt;
+      &lt;label class='gc-font-secondary' for="link-2770123" aria-label="link-2770123"&gt;
+        Share Link
+      &lt;/label&gt;
+      &lt;input class='js-copy-link form-control' id="link-2770123" value="https://www.gocomics.com/9chickweedlane/2019/07/16" aria-label='Get the permalink' data-clipboard-target="#link-2770123"&gt;
+    &lt;/fieldset&gt;
+  &lt;/form&gt;
+&lt;/div&gt;
+&lt;/div&gt;
+
+      &lt;/div&gt;
+
+  &lt;/div&gt;
+
+    &lt;div class='comic__buy-button'&gt;
+      &lt;a class="btn btn-primary gc-button" alt="Buy a Print of This Comic" data-link-type="feature-item-buy-print" href="https://store.gocomics.com/product/custom-print-order?publish_date=20190716&amp;amp;feature_code=cw&amp;amp;featureName=9 Chickweed Lane&amp;amp;hash=d4571e307e420137a88c005056a9545d"&gt;Buy a Print of This Comic&lt;/a&gt;
+      &lt;a class="btn btn-outline-primary gc-button" alt="Buy a Print of This Comic" data-link-type="feature-item-license" href="https://licensing.andrewsmcmeel.com/features/cw?date=2019-07-16"&gt;License This Comic&lt;/a&gt;
+    &lt;/div&gt;
+
+&lt;/div&gt;
+
+
+
+
+        &lt;h2 class="gc-section-title-more text-center content-section-sm"&gt;More From 9 Chickweed Lane&lt;/h2&gt;
+        
+
+&lt;div class='row'&gt;
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_self" href="https://www.gocomics.com/9chickweedlane"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_cap_flare_201705121044.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_cw_cap_flare_201705121044.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_cw_cap_flare_201705121044.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_cap_flare_201705121044.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Rita_promo_201901081106.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_Rita_promo_201901081106.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_Rita_promo_201901081106.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Rita_promo_201901081106.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--is-ad"&gt;
+          &lt;section class='card gc-card gc-card--ad-rectangle group-item-ad'&gt;
+            
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-rectangle-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="rectangle1" class="js-ad-lazy-load js-ad-refresh gc-ad ad-rectangle" data-ad-type="rectangle1"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+          &lt;/section&gt;
+      &lt;/div&gt;
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Gross_promo_201901081112.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_Gross_promo_201901081112.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_Gross_promo_201901081112.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Gross_promo_201901081112.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Brussels_promo_201901081115.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_Brussels_promo_201901081115.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_Brussels_promo_201901081115.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Brussels_promo_201901081115.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_allied_spy_740x700.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_cw_allied_spy_740x700.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_cw_allied_spy_740x700.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_allied_spy_740x700.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_CatBreath_promo_201901080851.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_CatBreath_promo_201901080851.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_CatBreath_promo_201901080851.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_CatBreath_promo_201901080851.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_PibgornPoltergise_201901080857.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_PibgornPoltergise_201901080857.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_PibgornPoltergise_201901080857.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_PibgornPoltergise_201901080857.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--is-ad"&gt;
+          &lt;section class='card gc-card gc-card--ad-rectangle group-item-ad'&gt;
+            
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-rectangle-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="rectangle2" class="js-ad-lazy-load js-ad-refresh gc-ad ad-rectangle" data-ad-type="rectangle2"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+          &lt;/section&gt;
+      &lt;/div&gt;
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_PubertyDetonation_promo_201901080859.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_PubertyDetonation_promo_201901080859.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_PubertyDetonation_promo_201901080859.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_PubertyDetonation_promo_201901080859.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Sonata_promo_201901081100.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_Sonata_promo_201901081100.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_Sonata_promo_201901081100.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Sonata_promo_201901081100.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_14_Dumpster_201902080835.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_14_Dumpster_201902080835.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_14_Dumpster_201902080835.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_14_Dumpster_201902080835.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_5_Crud_promo_201902080845.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_5_Crud_promo_201902080845.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_5_Crud_promo_201902080845.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_5_Crud_promo_201902080845.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_7_Satan_promo_201902080846.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_7_Satan_promo_201902080846.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_7_Satan_promo_201902080846.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_7_Satan_promo_201902080846.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_12_Borgia_promo_201902080848.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_12_Borgia_promo_201902080848.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_12_Borgia_promo_201902080848.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_12_Borgia_promo_201902080848.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_13_MSND_promo_201902080849.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_13_MSND_promo_201902080849.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_13_MSND_promo_201902080849.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_13_MSND_promo_201902080849.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_10_CoffeeCup_Promo_201902080847.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_10_CoffeeCup_Promo_201902080847.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_10_CoffeeCup_Promo_201902080847.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_10_CoffeeCup_Promo_201902080847.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://thecelebritycafe.com/2017/01/interview-9-chickweed-lanepibgorn-comics-creator-brooke-mceldowney/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_w_title_large_cw_McEldowney-interview-link-art.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_w_title_mid_cw_McEldowney-interview-link-art.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_w_title_small_cw_McEldowney-interview-link-art.jpg 150w" sizes="auto" width="100%" alt="Interview with ‘9 Chickweed Lane/Pibgorn’ comics creator Brooke McEldowney" src="//assets.gocomics.com/uploads/features/cw/widgets/link_w_title_large_cw_McEldowney-interview-link-art.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+    &lt;div class="card-body gc-card__body"&gt;
+      
+
+&lt;h4 class="card-title"&gt;Interview with ‘9 Chickweed Lane/Pibgorn’ comics creator Brooke McEldowney&lt;/h4&gt;
+
+&lt;h5 class="card-subtitle text-muted"&gt;LINK&lt;/h5&gt;
+      
+      
+      
+      
+
+
+
+
+
+
+    &lt;/div&gt;
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://chickweedcafe.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_blog_740x700.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_cw_blog_740x700.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_cw_blog_740x700.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_blog_740x700.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" href="/blog/3170/brooke-mceldowney-9-chickweed-lane-pibgorn"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image lazyload__padder lazyload__padder--card"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/default_images/default_image_large_meet_your_creator_meetyourcreator-generic.jpg 600w, //assets.gocomics.com/uploads/default_images/default_image_mid_meet_your_creator_meetyourcreator-generic.jpg 300w, //assets.gocomics.com/uploads/default_images/default_image_small_meet_your_creator_meetyourcreator-generic.jpg 150w" sizes="auto" width="100%" alt="Brooke McEldowney (9 Chickweed Lane, Pibgorn)" src="//assets.gocomics.com/uploads/default_images/default_image_large_meet_your_creator_meetyourcreator-generic.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+    &lt;div class="card-body gc-card__body"&gt;
+      
+
+&lt;h4 class="card-title"&gt;Brooke McEldowney (9 Chickweed Lane, Pibgorn)&lt;/h4&gt;
+
+&lt;h5 class="card-subtitle text-muted"&gt;GoComics&lt;/h5&gt;
+      
+      
+      
+      &lt;p class="card-text text-muted"&gt;October 04, 2014&lt;/p&gt;
+
+
+
+
+
+
+    &lt;/div&gt;
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" href="/blog/4428/see-no-10-in-gocomics-top-10-most-read-for-2017"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image lazyload__padder lazyload__padder--card"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/blogs/blog_image_large_4428_10884_9cwl_blog_post_201801041045.jpg 600w, //assets.gocomics.com/uploads/blogs/blog_image_mid_4428_10884_9cwl_blog_post_201801041045.jpg 300w, //assets.gocomics.com/uploads/blogs/blog_image_small_4428_10884_9cwl_blog_post_201801041045.jpg 150w" sizes="auto" width="100%" alt="See No. 10 in GoComics&amp;#39; Top-10 Most-Read for 2017" src="//assets.gocomics.com/uploads/blogs/blog_image_large_4428_10884_9cwl_blog_post_201801041045.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+    &lt;div class="card-body gc-card__body"&gt;
+      
+
+&lt;h4 class="card-title"&gt;See No. 10 in GoComics' Top-10 Most-Read for 2017&lt;/h4&gt;
+
+&lt;h5 class="card-subtitle text-muted"&gt;John Glynn&lt;/h5&gt;
+      
+      
+      
+      &lt;p class="card-text text-muted"&gt;January 08, 2018&lt;/p&gt;
+
+
+
+
+
+
+    &lt;/div&gt;
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+&lt;/div&gt;
+  &lt;/div&gt;
+
+
+
+
+      &lt;/div&gt;
+
+    &lt;/div&gt;
+  &lt;/div&gt;
+
+    &lt;div id='recommendations_holder' class='js-post-load-init' data-url="/favorites/recommendations.js?short_name=9chickweedlane"&gt;&lt;/div&gt;
+
+  
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-tynt-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="tynt" class="js-ad js-ad-refresh gc-ad ad-tynt" data-ad-type="tynt"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+
+
+
+      &lt;/div&gt;
+
+      
+&lt;div class="amu-container-ad-wrapper js-destructable fixed-ad-bottom fixed-ad-bottom--banner js-ad-banner-lock-wrapper ad-hidden"&gt;
+	&lt;div class="amu-container-ad ad-banner-lock-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="banner_lock" class="js-ad js-ad-refresh gc-ad ad-banner-lock" data-ad-type="banner_lock"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+      
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-banner-bottom-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="banner_bot" class="js-ad-lazy-load js-ad-refresh gc-ad ad-banner-bottom" data-ad-type="banner_bot"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;footer class="gc-page gc-page--gutters-none gc-footer bg-white"&gt;
+  &lt;div class="gc-page__full"&gt;
+    &lt;div class="container gc-footer__links"&gt;
+      &lt;div class="gc-content"&gt;
+        
+          &lt;div class="gc-content__4col"&gt;
+            &lt;h5 class='text-muted font-weight-normal'&gt;Find Comics&lt;/h5&gt;
+            &lt;ul class='gc-footer__list'&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/comics/trending"&gt;Trending&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/comics/political"&gt;Political Cartoons&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/comics/web-comics"&gt;Web Comics&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="/comics/categories"&gt;All Categories&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/comics/popular"&gt;Popular Comics&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/comics/a-to-z"&gt;A-Z Comics by Title&lt;/a&gt;&lt;/li&gt;
+              &lt;!--&lt;li&gt;&lt;/li&gt;--&gt;
+              &lt;!--&lt;li&gt;&lt;/li&gt;--&gt;
+            &lt;/ul&gt;
+          &lt;/div&gt;
+          
+          &lt;div class="gc-content__4col"&gt;
+            &lt;h5 class='text-muted font-weight-normal'&gt;More GoComics&lt;/h5&gt;
+            &lt;ul class='gc-footer__list'&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/blog"&gt;GoComics Blog&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" target="_blank" data-link-type="footer-nav" href="http://www.comicssherpa.com/site/index"&gt;Visit Comics Sherpa&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" target="_blank" data-link-type="footer-nav" href="http://www.facebook.com/gocomics"&gt;GC on Facebook&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" target="_blank" data-link-type="footer-nav" href="http://www.twitter.com/gocomics"&gt;GC on Twitter&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" target="_blank" data-link-type="footer-nav" href="http://www.instagram.com/gocomics"&gt;GC on Instagram&lt;/a&gt;&lt;/li&gt;
+                &lt;li&gt;&lt;a class="gc-footer__item" target="_blank" data-link-type="footer-nav" href="https://store.gocomics.com/"&gt;Shop&lt;/a&gt;&lt;/li&gt;
+            &lt;/ul&gt;
+          &lt;/div&gt;
+
+        &lt;div class="gc-content__4col"&gt;
+          &lt;h5 class="text-muted font-weight-normal"&gt;Account&lt;/h5&gt;
+          &lt;ul class="gc-footer__list"&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" rel="nofollow" data-link-type="footer-nav" href="https://www.gocomics.com/help/why-upgrade-to-premium-ad-free-subscription"&gt;Free Trial&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" rel="nofollow" data-link-type="footer-nav" href="https://www.gocomics.com/profiles/sign-in"&gt;Sign in&lt;/a&gt;&lt;/li&gt;
+
+            &lt;li&gt;&lt;a class="gc-footer__item" rel="nofollow" data-link-type="footer-nav" href="https://www.gocomics.com/profiles/gift-subscription"&gt;Gift Premium&lt;/a&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a class="gc-footer__item" rel="nofollow" data-link-type="footer-nav" href="https://www.gocomics.com/profiles/gift-subscription/redeem"&gt;Redeem a Gift&lt;/a&gt;&lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/div&gt;
+
+        &lt;div class="gc-content__4col"&gt;
+          &lt;h5 class="text-muted font-weight-normal"&gt;About&lt;/h5&gt;
+          &lt;ul class="gc-footer__list"&gt;
+            &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/help/about"&gt;About GoComics&lt;/a&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/help"&gt;Help &amp;amp; FAQ&lt;/a&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/help/advertising"&gt;Advertising&lt;/a&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/help/contact"&gt;Contact Us&lt;/a&gt;&lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;!-- /.gc-footer --&gt;
+    
+    &lt;div class="gc-footer__copyright"&gt;
+      &lt;span&gt;
+        &amp;copy; Copyright
+          9 Chickweed Lane, © Brooke McEldowney&lt;br class="d-sm-none"/&gt;
+        2019. All Rights Reserved.
+        &lt;a class="gc-footer__copyright-link" data-link-type="footer-nav" href="https://www.gocomics.com/help/terms"&gt;Terms &amp;amp; Conditions&lt;/a&gt;
+        -
+        &lt;a target="_blank" class="gc-footer__copyright-link" data-link-type="footer-nav" href="//www.andrewsmcmeel.com/privacy-policy"&gt;Privacy Policy&lt;/a&gt;
+      &lt;/span&gt;
+    &lt;/div&gt;&lt;!-- /.footer-copyright --&gt;
+  &lt;/div&gt;
+&lt;/footer&gt;&lt;!-- /.amu-container-footer --&gt;
+    &lt;/div&gt;
+
+      
+&lt;div class="modal fade" id="js-modal-account-hook" tabindex="-1" role="dialog" aria-labelledby="Join GoComics!" aria-hidden="true"&gt;
+  &lt;div class="modal-dialog" role="document"&gt;
+    &lt;div class="modal-content bg-info text-white"&gt;
+      &lt;div class="modal-header"&gt;
+        &lt;div class="modal-title h2"&gt;You must have an account to access this feature&lt;/div&gt;
+        &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
+          &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
+        &lt;/button&gt;
+      &lt;/div&gt;
+      &lt;div class="modal-body text-center"&gt;
+
+          &lt;a class="btn btn-light gc-button" data-link-type="modal-account-hook" href="/profiles/sign-in"&gt;Sign in&lt;/a&gt;
+          &lt;a class="btn btn-outline-light gc-button" data-link-type="modal-account-hook" href="/profiles/sign-up?account_type=free"&gt;Sign up for free&lt;/a&gt;
+          &lt;a class="btn btn-outline-light gc-button" data-link-type="modal-account-hook" href="/help/why-upgrade-to-premium-ad-free-subscription"&gt;Free Trial&lt;/a&gt;
+
+
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+
+    &lt;script src="https://assets.gocomics.com/assets/application-gc-postload-38c495659fa74c6bdbdef491358d7e8770448401a22883e612c250e793eba21f.js"&gt;&lt;/script&gt;
+
+    
+
+    &lt;script src="https://assets.gocomics.com/assets/apollo-8d36fd370ca1a24d2d6322970a4b520718a53c12ea96b5e6d85090ecb4f11d93.js?sampling=100"&gt;&lt;/script&gt;
+
+    &lt;div class="amu-layout-size"&gt;
+	&lt;span class="js-layout-size-xl d-none d-xl-block"&gt;&lt;/span&gt;
+	&lt;span class="js-layout-size-lg d-none d-lg-block d-xl-none"&gt;&lt;/span&gt;
+  &lt;span class="js-layout-size-md d-none d-md-block d-lg-none"&gt;&lt;/span&gt;
+  &lt;span class="js-layout-size-sm d-none d-sm-block d-md-none"&gt;&lt;/span&gt;
+  &lt;span class="js-layout-size-xs d-block d-sm-none"&gt;&lt;/span&gt;
+&lt;/div&gt;
+
+    &lt;a class="btn btn-secondary gc-back-to-top" href="#top"&gt;&lt;i class='gc-icon gc-icon-fluid fa fa-caret-up sm'&gt;&lt;/i&gt; Back To Top&lt;/a&gt;
+
+  &lt;/body&gt;
+&lt;/html&gt;
+</ReturnValue>
+    <OutAndRefValues />
+  </RecordedCall>
+  <RecordedCall>
+    <Method>System.String GetContent(System.Uri)</Method>
+    <ReturnValue xsi:type="xsd:string">&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+  &lt;title&gt;Homepage | Dilbert by Scott Adams&lt;/title&gt;
+  &lt;link href='https://fonts.googleapis.com/css?family=Raleway:800' rel='stylesheet' type='text/css'&gt;
+  &lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-57x57-e0b4e5677903a73270dfdbbdf453822ec6f41670be1e04b72bc50ba1a7190452.png" sizes="57x57" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-114x114-4df35bbdab93b653a1b2f7b87339b7275ae0bf5cd2405ef0039a9bf767a89672.png" sizes="114x114" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-72x72-32ed2d8b00c89f8970de5868ef96f918328d9ae53c09c16ff7c141557919d050.png" sizes="72x72" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-144x144-cbf35f76ba876c6bc1c2bf036ab7dcb680d39adfcc926e2f3f805a9bbfa3c421.png" sizes="144x144" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-60x60-99fbd11d8f9549f0b27a7bc6886299c887c3a5d70cc16ce57248c204ee06619f.png" sizes="60x60" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-120x120-9f04dc1f1f49ed25b3ab07923f434750424bf94a06ef51cbbec340e8ce6d71c7.png" sizes="120x120" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-76x76-ae33c10c412af3059d008a78a3b9230ed9acbfe3cff0ea779d34595ced8f18cd.png" sizes="76x76" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-152x152-45e8cce5279b39b468df54735e23a403775ef5e55a28ca1f90b5c2ba5fc5a1f1.png" sizes="152x152" /&gt;
+&lt;link rel="icon" type="image/png" href="/assets/favicon/favicon-196x196-cf4d86b485e628a034ab8b961c1c3520b5969252400a80b9eed544d99403e037.png" sizes="196x196" /&gt;
+&lt;link rel="icon" type="image/png" href="/assets/favicon/favicon-160x160-3ea5e996022211d066e9ce9ac4f17b398f59116ff5954986a60d8b022a871238.png" sizes="160x160" /&gt;
+&lt;link rel="icon" type="image/png" href="/assets/favicon/favicon-96x96-c82238e3f09749e48ac48a4b3b49b0fa88e485e6303c5be727c026d32843841f.png" sizes="96x96" /&gt;
+&lt;link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32-d68bbf274659c3a17c78e06e7cedc102423d49707228292768bc433599f4bdd9.png" sizes="32x32" /&gt;
+&lt;link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16-02c369cb01fd85c99a5d8a3c113aba4178e35db3680a89be5df48cd49b47d8a1.png" sizes="16x16" /&gt;
+&lt;link rel="shortcut icon" type="image/x-icon" href="/assets/favicon/favicon-018fc74a59c534d43442c3893ac35b4771efa080c16159257bede9a46a798d0b.ico" /&gt;
+&lt;meta name="msapplication-TileColor" content="#ffffff" /&gt;
+&lt;meta name="msapplication-TileImage" content="/assets/favicon/mstile-144x144-b6ab8a12c34e35c1e7587ba2662654ebf5be75fa53e15a130105d1838df90d23.png" /&gt;
+  &lt;meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1"&gt;
+&lt;meta name="viewport" content="width=device-width, initial-scale=1.0"&gt;
+&lt;meta name="keywords" content="official dilbert website, dilbert comic strip, scott adams, Dilbert, Dogbert, Wally, The Pointy Haired Boss, Alice, Asok, Dogberts New Ruling Class, catbert, ratbert, mashups, animation, comics"&gt;
+&lt;meta name="description" content="The Official Dilbert Website featuring Scott Adams Dilbert strips, animation, mashups and more starring Dilbert, Dogbert, Wally, The Pointy Haired Boss, Alice, Asok, Dogberts New Ruling Class and more."&gt;
+&lt;meta name="twitter:creator" content="Dilbert_Daily"&gt;
+&lt;meta name="csrf-param" content="authenticity_token" /&gt;
+&lt;meta name="csrf-token" content="NF1anBWfSijL65KJBkpq2mbZcsNAmfmNUesXZdLZxtK95txBKHqyOi7Blf4tkleOB/IovmprG9B9SrfGq7G2Fg==" /&gt;
+    &lt;!-- Global Sharing --&gt;
+    &lt;!-- Facebook Open Graph Tags --&gt;
+    &lt;meta property="og:url" content="http://dilbert.com/"/&gt;
+    &lt;meta property="og:type" content="website"/&gt;
+    &lt;meta property="og:title" content="Welcome to Dilbert"/&gt;
+    &lt;!-- &lt;meta property="og:image" content=""/&gt; --&gt;
+    &lt;meta property="og:description" content="The Official Dilbert Website featuring Scott Adams Dilbert strips, animation, mashups and more starring Dilbert, Dogbert, Wally, The Pointy Haired Boss, Alice, Asok, Dogberts New Ruling Class and more."/&gt;
+    &lt;meta property="og:site_name" content="Dilbert"/&gt;
+    &lt;meta property="fb:app_id" content="163128967074041"/&gt;
+
+    &lt;!-- Dynamic Twitter Card Meta Tags --&gt;
+    &lt;meta name="twitter:url" content="http://dilbert.com/"&gt;
+    &lt;meta name="twitter:card" content="summary"&gt;
+    &lt;meta name="twitter:site" content="@Dilbert"&gt;
+    &lt;meta name="twitter:title" content="Welcome to Dilbert"&gt;
+    &lt;meta name="twitter:domain" content="https://dilbert.com/"&gt;
+    &lt;meta name="twitter:description" content="The Official Dilbert Website featuring Scott Adams Dilbert strips, animation, mashups and more starring Dilbert, Dogbert, Wally, The Pointy Haired Boss, Alice, Asok, Dogberts New Ruling Class and more."&gt;
+    &lt;!-- &lt;meta name="twitter:image:src" content=""&gt; --&gt;
+
+&lt;!-- Webmaster Tools Verification --&gt;
+&lt;meta name="google-site-verification" content="iMe_GbOppnxshIHn7KwTW8Eey9Lfzflvc9NrzGPoewI" /&gt;
+
+    &lt;link rel="canonical" href="https://www.dilbert.com/"&gt;
+
+  &lt;link rel="stylesheet" media="all" href="/assets/global-icons-f9068ad35b7b28d4fb587d113f115003b27c63ead4604513937269cbbe49216f.css" /&gt;
+  &lt;link rel="stylesheet" media="screen" href="/assets/packs/application-bb3b372ba6507e3db2c6a1ebcff62b0f.css" /&gt;
+
+  &lt;script src="/assets/cookies-b2884013a1ad9180342f0af884cc791f69592cbf0ad8431da28ce98cce758b26.js"&gt;&lt;/script&gt;
+
+  &lt;script async="" src="https://confiant-integrations.global.ssl.fastly.net/DN19JX_5rrJXKmPMrwRRdO8wyOY/gpt_and_prebid/config.js"&gt;&lt;/script&gt;
+
+&lt;!-- Prebid wrapper, intersection observer polyfill --&gt;
+&lt;script src="/assets/packs/ad-dependencies-2e7854e456812ad6a881.js"&gt;&lt;/script&gt;
+
+&lt;!-- Venatus Market Ad-Manager (dilbert.com) --&gt;
+&lt;script&gt;
+    (function(){document.write('&lt;div id="vmv3-ad-manager" style="display:none"&gt;&lt;/div&gt;');document.getElementById("vmv3-ad-manager").innerHTML='&lt;iframe id="vmv3-frm" src="javascript:\'&lt;html&gt;&lt;body&gt;&lt;/body&gt;&lt;/html&gt;\'" width="0" height="0" data-mode="scan" data-site-id="5b0433f746e0fb00017bc7d6"&gt;&lt;/iframe&gt;';var a=document.getElementById("vmv3-frm");a=a.contentWindow?a.contentWindow:a.contentDocument;a.document.open();a.document.write('&lt;script src="https://hb.vntsm.com/v3/live/ad-manager.min.js" type="text/javascript" async&gt;'+'&lt;/scr'+'ipt&gt;');a.document.close()})();
+&lt;/script&gt;
+&lt;!-- / Venatus Market Ad-Manager (dilbert.com) --&gt;
+
+&lt;!-- GPT --&gt;
+&lt;script async="async" src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"&gt;&lt;/script&gt;
+
+&lt;!-- Amazon --&gt;
+&lt;script&gt;
+    !function(a9,a,p,s,t,A,g){if(a[a9])return;function q(c,r){a[a9]._Q.push([c,r])}a[a9]={init:function(){q("i",arguments)},fetchBids:function(){q("f",arguments)},setDisplayBids:function(){},targetingKeys:function(){return[]},_Q:[]};A=p.createElement(s);A.async=!0;A.src=t;g=p.getElementsByTagName(s)[0];g.parentNode.insertBefore(A,g)}("apstag",window,document,"script","////c.amazon-adsystem.com/aax2/apstag.js");
+&lt;/script&gt;
+
+&lt;script&gt;
+    /***** Helper functions for ads *****/
+    var storeQueryString = function(){
+        var queryString = window.location.search.substring(1).split('&amp;');
+        for(var i=0; i&lt;queryString.length; i++){
+            var pair = queryString[i].split('=');
+            if(pair.length === 2){
+                amu_ads.query_string[pair[0]] = pair[1];
+            }
+        }
+    };
+
+    var findAds = function(className) {
+        var ads = document.getElementsByClassName(className);
+        ads = Array.prototype.slice.call(ads);
+        ads.map(function(element) {element.classList.remove(className);});
+
+        return ads
+    };
+
+    var getAdInfo = function (adElements) {
+        var adIds = adElements.map(getElementInfo);
+        adIds = adIds.filter(adSlotConfigExists).filter(servesAtBreakpoint);
+
+        return adIds;
+    };
+
+    var getAdSlot = function (slotInfo) {
+        return amu_ads.adSlots[slotInfo.id];
+    };
+
+    var adSlotConfigExists = function(slotInfo){
+        return typeof amu_ads.adSlotConfig[slotInfo.adType] !== 'undefined';
+    };
+
+    var servesAtBreakpoint = function(slotInfo){
+        var curBpt = amu_ads.adSlotConfig[slotInfo.adType].breakpoint;
+        return curBpt.sizes.length &gt; 0;
+    };
+
+    var getElementId = function(element){
+        return element.id;
+    };
+
+    var getElementAdType = function(element){
+        return element.getAttribute('data-ad-type');
+    };
+
+    var getElementInfo = function(element){
+        return {id: getElementId(element), adType: getElementAdType(element)};
+    };
+
+    var findBreakpoint = function(breakpointsArray){
+        var maxBpt, curBpt;
+        for (var i = 0; i &lt; breakpointsArray.length; i++) {
+            curBpt = breakpointsArray[i];
+            if (amu_ads.browserWidth &gt;= curBpt.minWidth &amp;&amp; amu_ads.browserHeight &gt;= curBpt.minHeight){
+                if(!maxBpt || (curBpt.minWidth &gt;= maxBpt.minWidth &amp;&amp; curBpt.minHeight &gt;= maxBpt.minHeight)){
+                    maxBpt = curBpt;
+                }
+            }
+        }
+        return maxBpt
+    };
+
+
+    var updatePageviewTargeting = function() {
+        var adPageview = getPageviewFromCookie();
+        Object.keys(amu_ads.adSlotConfig).forEach(function(key) {
+            amu_ads.adSlotConfig[key].targeting['pv'] = adPageview;
+        });
+    };
+
+    var adLazyLoaderInit = function (className) {
+        var adElements = Array.prototype.slice.call(document.getElementsByClassName(className));
+
+        adElements.forEach(function(element) {
+            element.classList.remove(className);
+            amu_ads.adLazyLoader.observe(element);
+        });
+    };
+
+    var adRefresherInit = function (className) {
+        if(!isEU){
+            var adElements = Array.prototype.slice.call(document.getElementsByClassName(className));
+
+            adElements.forEach(function(element) {
+                element.classList.remove(className);
+                amu_ads.adRefresher.observe(element);
+            });
+
+            if(typeof(amu_ads.adRefreshInterval) === 'undefined') {
+                amu_ads.adRefreshInterval = window.setInterval(handleAdRefreshInterval, amu_ads.adRefreshRate);
+            }
+        }
+    };
+
+    var handleAdLazyLoad = function (entries, observer) {
+        entries.forEach(function(entry) {
+            if(entry.isIntersecting){
+                // run auction on these elements
+                var adInfo = getAdInfo([entry.target]);
+                auctionInit(adInfo, false);
+                amu_ads.adLazyLoader.unobserve(entry.target);
+            }
+        });
+    };
+
+    var handleAdRefresh = function (entries, observer) {
+        var curAdId, curAdElement;
+        entries.forEach(function(entry) {
+            curAdElement = entry.target;
+            curAdId = curAdElement.id;
+            if(entry.intersectionRatio &gt;= 0.50) {
+                if(amu_ads.adSlots[curAdId]){
+                    amu_ads.inViewAds[curAdId] = curAdElement;
+                }
+            } else {
+                delete amu_ads.inViewAds[curAdId];
+            }
+        });
+    };
+
+    var handleAdRefreshInterval = function () {
+        if(amu_ads.adRefreshCount &lt; amu_ads.adRefreshMax) {
+            if(!document.hidden){
+
+                // Refresh in view ads
+                var adInfo = getAdInfo(Object.values(amu_ads.inViewAds));
+                auctionInit(adInfo, true);
+                // Update refresh count and clear inViewAds
+                amu_ads.adRefreshCount += 1;
+            }
+        } else {
+
+            // Stop refreshing
+            clearInterval(amu_ads.adRefreshInterval)
+        }
+    }
+
+&lt;/script&gt;
+&lt;script&gt;
+    // Global variable for advertising config
+    var amu_ads = amu_ads || {};
+
+    // Query string for changing ad slot path and ad channel
+    amu_ads.query_string = amu_ads.query_string || {};
+
+    // Browser and page info
+    amu_ads.browserWidth = "CSS1Compat" == window.document.compatMode ? window.document.documentElement.clientWidth : window.document.body.clientWidth;
+    amu_ads.browserHeight = "CSS1Compat" == window.document.compatMode ? window.document.documentElement.clientHeight : window.document.body.clientHeight;
+    amu_ads.pageDomain = window.location.hostname;
+    amu_ads.pagePath = window.location.pathname + location.search + location.hash;
+
+    // Ad channel (a or b)
+    //amu_ads.adChannel = '';
+
+    // Current page view number (based on cookie)
+    amu_ads.adPageview = setPageviewCookie();
+
+    // Ad unit path
+    amu_ads.adSlotPath = '/19196947/dilbert.com/home';
+
+
+    // Intersection observer for lazy loading ads
+    amu_ads.adLazyLoadOptions = {
+        rootMargin: amu_ads.browserWidth &gt;= 992 ? '200px' : '100px',
+        threshold: 0
+    };
+    amu_ads.adLazyLoader = new IntersectionObserver(handleAdLazyLoad, amu_ads.adLazyLoadOptions);
+
+
+    // Intersection observer for refreshing in view ads
+    amu_ads.adRefreshOptions = {
+        threshold: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+    };
+    amu_ads.adRefresher = new IntersectionObserver(handleAdRefresh, amu_ads.adRefreshOptions);
+    amu_ads.inViewAds = {};
+    amu_ads.adRefreshCount = 0;
+    amu_ads.adRefreshMax = 5;
+    amu_ads.adRefreshRate = 30000;
+
+    // Place to store DFP ad slots (needed in order to refresh ads)
+    amu_ads.adSlots = {};
+
+
+
+
+    /***** Bidder config *****/
+    // AppNexus tag config
+    amu_ads.appnexusTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869757,
+                keywords: {
+                    pos: ['top']
+                }
+            }
+        },
+
+
+        // 970x250, 970x90, 728x90, 320x50
+        'bot': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869751,
+                keywords: {
+                    pos: ['bot']
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        'right': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869756,
+                keywords: {
+                    pos: ['right']
+                }
+            }
+        },
+
+        // 300x250
+        'left': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869754,
+                keywords: {
+                    pos: ['left']
+                }
+            }
+        },
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'content': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869753,
+                keywords: {
+                    pos: ['content']
+                }
+            }
+        },
+
+        // 160x600, 300x600
+        'comments': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869752,
+                keywords: {
+                    pos: ['comments']
+                }
+            }
+        },
+
+        // 160x600
+        'anchored': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869750,
+                keywords: {
+                    pos: ['anchored']
+                }
+            }
+        }
+    };
+
+
+    // Index tag config
+    amu_ads.ixTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        '970x250_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '294963',
+                size: [970,250]
+            }
+        },
+        '970x90_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '294963',
+                size: [970,90]
+            }
+        },
+        '728x90_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '294963',
+                size: [728,90]
+            }
+        },
+        '320x50_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '294963',
+                size: [320,50]
+            }
+        },
+
+        // 970x250, 970x90, 728x90, 320x50
+        '970x250_bot': {
+            bidder: 'ix',
+            params: {
+                siteId: '294957',
+                size: [970, 250]
+            }
+        },
+        '970x90_bot': {
+            bidder: 'ix',
+            params: {
+                siteId: '294957',
+                size: [970, 90]
+            }
+        },
+        '728x90_bot': {
+            bidder: 'ix',
+            params: {
+                siteId: '294957',
+                size: [728, 90]
+            }
+        },
+        '320x50_bot': {
+            bidder: 'ix',
+            params: {
+                siteId: '294957',
+                size: [320, 50]
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '300x250_left': {
+            bidder: 'ix',
+            params: {
+                siteId: '294960',
+                size: [300,250]
+            }
+        },
+
+        // 300x250
+        '300x250_right': {
+            bidder: 'ix',
+            params: {
+                siteId: '294962',
+                size: [300,250]
+            }
+        },
+
+
+        /***** Towers *****/
+        // 300x600, 300x250, 160x600
+        '300x600_content': {
+            bidder: 'ix',
+            params: {
+                siteId: '294959',
+                size: [300, 600]
+            }
+        },
+        '300x250_content': {
+            bidder: 'ix',
+            params: {
+                siteId: '294959',
+                size: [300,250]
+            }
+        },
+        '160x600_content': {
+            bidder: 'ix',
+            params: {
+                siteId: '294959',
+                size: [160,600]
+            }
+        },
+
+
+        // 300x600, 160x600
+        '300x600_comments': {
+            bidder: 'ix',
+            params: {
+                siteId: '294958',
+                size: [300, 600]
+            }
+        },
+        '160x600_comments': {
+            bidder: 'ix',
+            params: {
+                siteId: '294958',
+                size: [160,600]
+            }
+        },
+
+
+        // 160x600
+        '160x600_anchored': {
+            bidder: 'ix',
+            params: {
+                siteId: '294956',
+                size: [160, 600]
+            }
+        }
+    };
+
+    // OpenX tag config
+    amu_ads.openxTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'openx',
+            params: {
+                unit: 540251690,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'top'
+                }
+            }
+        },
+
+
+        // 970x250, 970x90, 728x90, 320x50
+        'bot': {
+            bidder: 'openx',
+            params: {
+                unit: 540251667,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'bot'
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        'left': {
+            bidder: 'openx',
+            params: {
+                unit: 540251683,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'left'
+                }
+            }
+        },
+
+        // 300x250
+        'right': {
+            bidder: 'openx',
+            params: {
+                unit: 540251687,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'right'
+                }
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x600, 300x250, 160x600
+        'content': {
+            bidder: 'openx',
+            params: {
+                unit: 540251676,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'content'
+                }
+            }
+        },
+
+        // 300x600, 160x600
+        'comments': {
+            bidder: 'openx',
+            params: {
+                unit: 540251672,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'comments'
+                }
+            }
+        },
+
+        // 160x600
+        'anchored': {
+            bidder: 'openx',
+            params: {
+                unit: 540251664,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'anchored'
+                }
+            }
+        }
+    };
+
+
+    // PubMatic tag config
+    amu_ads.pubmaticTags = {
+
+        /***** Leaderboards and banners *****/
+        // 728x90, 970x90, 970x250, 320x50
+        'top': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887698'
+            }
+        },
+
+
+        // 728x90, 970x90, 970x250, 320x50
+        'bot': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887692'
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        'left': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887695'
+            }
+        },
+
+        // 300x250
+        'right': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887697'
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 160x600, 300x250, 300x600
+        'content': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887694'
+            }
+        },
+
+        // 160x600, 300x600
+        'comments': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887693'
+            }
+        },
+
+        // 160x600
+        'anchored': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887691'
+            }
+        }
+    };
+
+
+    // Rubicon tag config
+    amu_ads.rubiconTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032618,
+                visitor: {
+                    'pos': ['top']
+                }
+            }
+        },
+
+
+        // 970x250, 970x90, 728x90, 320x50
+        'bot': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032600,
+                visitor: {
+                    'pos': ['bot']
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        'left': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032608,
+                visitor: {
+                    'pos': ['left']
+                }
+            }
+        },
+
+        // 300x250
+        'right': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032612,
+                visitor: {
+                    'pos': ['right']
+                }
+            }
+        },
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'content': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032604,
+                visitor: {
+                    'pos': ['content']
+                }
+            }
+        },
+
+        // 160x600, 300x600
+        'comments': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032602,
+                visitor: {
+                    'pos': ['comments']
+                }
+            }
+        },
+
+        // 160x600
+        'anchored': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032598,
+                visitor: {
+                    'pos': ['anchored']
+                }
+            }
+        }
+    };
+
+
+    // Sovrn tag config
+    amu_ads.sovrnTags = {
+        /***** Leaderboards and banners *****/
+        '970x250_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580516'
+            }
+        },
+        '728x90_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580515'
+            }
+        },
+        '320x50_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580517'
+            }
+        },
+
+        '970x250_bot': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580505'
+            }
+        },
+        '728x90_bot': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580504'
+            }
+        },
+        '320x50_bot': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580506'
+            }
+        },
+
+
+        /***** Rectangles *****/
+        '300x250_left': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580512'
+            }
+        },
+
+        '300x250_right': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580514'
+            }
+        },
+
+
+        /***** Towers *****/
+        '300x250_content': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580510'
+            }
+        },
+        '160x600_content': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580509'
+            }
+        },
+        '300x600_content': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580511'
+            }
+        },
+
+
+        '160x600_comments': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580507'
+            }
+        },
+        '300x600_comments': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580508'
+            }
+        },
+
+
+        '160x600_anchored': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580503'
+            }
+        },
+
+    };
+
+
+
+    /***** Ad config *****/
+    // TODO: refactor/consolidate ad slot configs when layouts are more consistent
+    amu_ads.adSlotConfig = {};
+    amu_ads.adSlotConfig['leaderboard'] = {
+        name: 'leaderboard',
+        targeting: {
+            'pos': 'top',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 970,
+                minHeight: 850,
+                sizes: [[970, 250], [970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x250_top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['970x250_top'],
+                    amu_ads.sovrnTags['728x90_top']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90], [320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.sovrnTags['320x50_top']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['320x50_top']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['leaderboard'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['leaderboard'].breakpoints);
+
+
+    amu_ads.adSlotConfig['banner'] = {
+        name: 'banner',
+        targeting: {
+            'pos': 'bot',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 250], [970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['bot'],
+                    amu_ads.ixTags['970x250_bot'],
+                    amu_ads.ixTags['970x90_bot'],
+                    amu_ads.ixTags['728x90_bot'],
+                    amu_ads.openxTags['bot'],
+                    amu_ads.pubmaticTags['bot'],
+                    amu_ads.rubiconTags['bot'],
+                    amu_ads.sovrnTags['970x250_bot'],
+                    amu_ads.sovrnTags['728x90_bot']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90], [320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['bot'],
+                    amu_ads.ixTags['728x90_bot'],
+                    amu_ads.ixTags['320x50_bot'],
+                    amu_ads.openxTags['bot'],
+                    amu_ads.pubmaticTags['bot'],
+                    amu_ads.rubiconTags['bot'],
+                    amu_ads.sovrnTags['728x90_bot'],
+                    amu_ads.sovrnTags['320x50_bot']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['bot'],
+                    amu_ads.ixTags['320x50_bot'],
+                    amu_ads.openxTags['bot'],
+                    amu_ads.pubmaticTags['bot'],
+                    amu_ads.rubiconTags['bot'],
+                    amu_ads.sovrnTags['320x50_bot']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner'].breakpoints);
+
+
+    amu_ads.adSlotConfig['rectangle'] = {
+        name: 'rectangle',
+        targeting: {
+            'pos': 'left',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['300x250_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['300x250_left']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['rectangle'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['rectangle'].breakpoints);
+
+
+    amu_ads.adSlotConfig['rectangle_right'] = {
+        name: 'rectangle_right',
+        targeting: {
+            'pos': 'right',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x250_right']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['rectangle_right'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['rectangle_right'].breakpoints);
+
+
+    amu_ads.adSlotConfig['tower_content'] = {
+        name: 'tower_content',
+        targeting: {
+            'pos': 'content',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 600], [160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['content'],
+                    amu_ads.ixTags['300x600_content'],
+                    amu_ads.ixTags['160x600_content'],
+                    amu_ads.openxTags['content'],
+                    amu_ads.pubmaticTags['content'],
+                    amu_ads.rubiconTags['content'],
+                    amu_ads.sovrnTags['300x600_content'],
+                    amu_ads.sovrnTags['160x600_content']
+                ]
+            },
+            {
+                minWidth: 768,
+                minHeight: 0,
+                sizes: [[160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['content'],
+                    amu_ads.ixTags['160x600_content'],
+                    amu_ads.openxTags['content'],
+                    amu_ads.pubmaticTags['content'],
+                    amu_ads.rubiconTags['content'],
+                    amu_ads.sovrnTags['160x600_content']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['content'],
+                    amu_ads.ixTags['300x250_content'],
+                    amu_ads.openxTags['content'],
+                    amu_ads.pubmaticTags['content'],
+                    amu_ads.rubiconTags['content'],
+                    amu_ads.sovrnTags['300x250_content']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_content'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_content'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tower_comments'] = {
+        name: 'tower_comments',
+        targeting: {
+            'pos': 'comments',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 600], [160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['comments'],
+                    amu_ads.ixTags['300x600_comments'],
+                    amu_ads.ixTags['160x600_comments'],
+                    amu_ads.openxTags['comments'],
+                    amu_ads.pubmaticTags['comments'],
+                    amu_ads.rubiconTags['comments'],
+                    amu_ads.sovrnTags['300x600_comments'],
+                    amu_ads.sovrnTags['160x600_comments']
+                ]
+            },
+            {
+                minWidth: 768,
+                minHeight: 0,
+                sizes: [[160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['comments'],
+                    amu_ads.ixTags['160x600_comments'],
+                    amu_ads.openxTags['comments'],
+                    amu_ads.pubmaticTags['comments'],
+                    amu_ads.rubiconTags['comments'],
+                    amu_ads.sovrnTags['160x600_comments']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_comments'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_comments'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tower_anchored'] = {
+        name: 'tower_anchored',
+        targeting: {
+            'pos': 'anchored',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 1400,
+                minHeight: 620,
+                sizes: [[160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['anchored'],
+                    amu_ads.ixTags['160x600_anchored'],
+                    amu_ads.openxTags['anchored'],
+                    amu_ads.pubmaticTags['anchored'],
+                    amu_ads.rubiconTags['anchored'],
+                    amu_ads.sovrnTags['160x600_anchored']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_anchored'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_anchored'].breakpoints);
+
+
+    amu_ads.adSlotConfig['tynt'] = {
+        name: 'tynt',
+        targeting: {
+            'pos': 'locked',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: []
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tynt'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tynt'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['venatus'] = {
+        name: 'ventatus',
+        targeting: {
+            'pos': 'venatus',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[1, 1]],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['venatus'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['venatus'].breakpoints);
+&lt;/script&gt;
+
+&lt;script&gt;
+    // Venatus
+    var isEU = false;
+    window.VM_API = window.VM_API || [];
+
+    var PREBID_TIMEOUT = 1500;
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+    var customPriceBuckets = {
+        'buckets': [
+            // 1 cent increments up to 50 cents
+            {
+                'min': 0.00,
+                'max': 0.50,
+                'increment': 0.01
+            },
+            // 5 cent increments up to 5 dollars
+            {
+                'min': 0.50,
+                'max': 5.00,
+                'increment': 0.05
+            },
+            // 10 cent increments up to 10 dollars
+            {
+                'min': 5.00,
+                'max': 10.00,
+                'increment': 0.10
+            },
+            // 50 cent increments up to 20 dollars
+            {
+                'min': 10.00,
+                'max': 20.00,
+                'increment': 0.50
+            },
+            // 1 dollar increments up to 50 dollars
+            {
+                'min': 20.00,
+                'max': 50.00,
+                'increment': 1.00
+            }
+        ]
+    };
+
+    pbjs.que.push(function() {
+        pbjs.setConfig({
+            enableSendAllBids: true,
+            priceGranularity: customPriceBuckets,
+            userSync: {
+                iframeEnabled: true,
+                filterSettings: {
+                    iframe: {
+                        bidders: '*',      // '*' represents all bidders
+                        filter: 'include'
+                    }
+                }
+            }
+        });
+    });
+
+
+    // Confiant
+    // Wrapper for AMUniversal (GoComics), generated on 2018-10-26T16:40:06-04:00, version 2018.04.02
+    pbjs.que.push(function() {
+
+        // keep a reference to original renderAd function
+        var w = window;
+        w._clrm = w._clrm || {};
+        w._clrm.renderAd = w._clrm.renderAd || pbjs.renderAd;
+        var config = w._clrm.prebid || {
+            /* Enables sandboxing on a device group
+                 All:1 , Desktop:2, Mobile: 3, iOS: 4, Android: 5, Off: 0
+             */
+            sandbox: 0
+        };
+
+        var isGoogleFrame = function (c) {
+            return c.tagName === 'IFRAME' &amp;&amp; c.id &amp;&amp; c.id.indexOf('google_ads_iframe_') &gt; -1;
+        };
+
+        var shouldSandbox = function () {
+            var uaToRegexMap = {
+                    "mobile": /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/i,
+                    "ios": /(.+)(iPhone|iPad|iPod)(.+)OS[\s|\_](\d)\_?(\d)?[\_]?(\d)?.+/i,
+                    "android": /Android/i
+                },
+                sbStr = "" +config.sandbox;
+            if (sbStr === "1") {
+                // all environments
+                return true;
+            } else if (sbStr === "2") {
+                // desktop
+                return !navigator.userAgent.match(uaToRegexMap["mobile"]);
+            } else if (sbStr === "3") {
+                // mobile
+                return navigator.userAgent.match(uaToRegexMap["mobile"]);
+            } else if (sbStr === "4") {
+                // ios only
+                return navigator.userAgent.match(uaToRegexMap["ios"]);
+            } else if (sbStr === "5") {
+                // android
+                return navigator.userAgent.match(uaToRegexMap["android"]);
+            } else {
+                return false;
+            }
+        };
+
+        Node.prototype.appendChild = (function (original) {
+            return function (child) {
+                if (isGoogleFrame(child) &amp;&amp; shouldSandbox() &amp;&amp; !child.getAttribute('sandbox')) {
+                    child.setAttribute('sandbox', 'allow-forms allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation');
+                    child.setAttribute('data-forced-sandbox', true);
+                }
+                return original.call(this, child);
+            };
+        }(Node.prototype.appendChild));
+
+
+        // override renderAd
+        pbjs.renderAd = function(doc, id) {
+            if (doc &amp;&amp; id) {
+                try {
+
+                    // get pbjs bids
+                    var bids = [],
+                        bidResponses = pbjs.getBidResponses(),
+                        highestBids = pbjs.getHighestCpmBids();
+                    for (var slot in bidResponses) {
+                        bids = bids.concat(bidResponses[slot].bids);
+                    }
+                    bids = bids.concat(highestBids);
+
+                    // lookup ad by ad Id (avoid ES6 array functions)
+                    var bid, i;
+                    for (i=0; i&lt;bids.length; i++) {
+                        if (bids[i].adId === id) {
+                            bid = bids[i];
+                            break;
+                        }
+                    }
+
+                    // Optional: list of bidders that don't need wrapping, array of strings, e.g.: ["bidder1", "bidder2"]
+                    var confiantExcludeBidders = [];
+
+                    // check bidder exclusion (avoid ES6 array functions)
+                    var excludeBidder = false;
+                    for (i=0; i&lt;confiantExcludeBidders.length; i++) {
+                        if (bid.bidder === confiantExcludeBidders[i]) {
+                            excludeBidder = true;
+                            break;
+                        }
+                    }
+
+                    if (bid &amp;&amp; bid.ad &amp;&amp; !excludeBidder) {
+                        // Neutralize document
+                        var docwrite = doc.write;
+                        var docclose = doc.close;
+                        doc.write = doc.close = function() {};
+                        // call renderAd with our neutralized doc.write
+                        window._clrm.renderAd(doc, id);
+                        // Restore document
+                        delete doc.write;
+                        delete doc.close;
+
+                        var callback = function(blockingType, blockingId, isBlocked, wrapperId, tagId, impressionData) {
+                            console.log("w00t one more bad ad nixed.", arguments);
+                        };
+
+                        return;
+                    }
+                } catch (e) {
+                    console.log(e);
+                }
+            }
+
+            // if bid.ad is not defined or if any error occurs, call renderAd to serve the creative
+            window._clrm.renderAd(doc, id);
+        };
+
+    });
+
+
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    googletag.cmd.push(function() {
+        googletag.pubads().disableInitialLoad();
+
+        // Event listener for when slot renders
+        //googletag.pubads().addEventListener('slotRenderEnded', function(event) {
+            // Element Id of the slot
+            //var slotId = event.slot.getSlotElementId();
+        //});
+    });
+
+    apstag.init({
+        pubID: 'af9aec0d-17e4-4619-825c-371fa3483a58',
+        adServer: 'googletag'
+    });
+&lt;/script&gt;
+
+&lt;script&gt;
+    function startAuction(bidTimeout, adInfo, adSlots, refresh) {
+        // Define bidders
+        var bidders = ['a9', 'prebid'];
+
+        // create a requestManager to keep track of bidder state to determine when to send ad server
+        // request and what apstagSlots to request from the ad server
+        var requestManager = {
+            adServerRequestSent: false
+        };
+        // add the bidders to the request manager:
+        bidders.forEach(function(bidder) {
+            requestManager[bidder] = false;
+        });
+
+        // return true if all bidders have returned
+        function allBiddersDone () {
+            return bidders.filter(function(bidder) {return requestManager[bidder];}).length === bidders.length;
+        }
+
+        // handler for header bidder responses
+        function bidderDone(bidder) {
+            if (requestManager.adServerRequestSent === false) {
+                // flip the boolean associated with the bidder in the request manager
+                requestManager[bidder] = true;
+
+                // if all bidders are back, send the request to the ad server
+                if (allBiddersDone()) {
+                    sendAdserverRequest(adInfo, adSlots, refresh);
+                }
+            }
+        }
+
+        // actually get ads from DFP
+        function sendAdserverRequest(adInfo, adSlots, refresh) {
+            if (requestManager.adServerRequestSent === false) {
+                requestManager.adServerRequestSent = true;
+                pbjs.que.push(function() {
+                    googletag.cmd.push(function() {
+                        if(!refresh){
+                            // 5. Display Ads
+                            displayAds(adInfo);
+                        }
+
+                        // 6. Refresh bids
+                        refreshAds(adSlots);
+                    });
+                });
+            }
+        }
+
+        function requestBids(adInfo, adSlots) {
+            // Fetch Amazon bids
+            amzn_fetchBids(adInfo, adSlots);
+
+            // Fetch Prebid bids
+            prebid_fetchBids(adInfo, adSlots);
+
+        }
+
+        /***** Amazon helper functions *****/
+        function amzn_buildSlotsArray(adInfo) {
+            var slotsArray = [];
+            var i, curAdId, curAdType;
+            for (i = 0; i &lt; adInfo.length; i++) {
+                curAdId = adInfo[i].id;
+                curAdType = adInfo[i].adType;
+                slotsArray.push({
+                    slotID: curAdId,
+                    sizes: amu_ads.adSlotConfig[curAdType].breakpoint.sizes
+                });
+            }
+            return slotsArray;
+
+        }
+
+        function amzn_fetchBids(adInfo, adSlots) {
+            // Fetch Amazon bids for slots on page
+            apstag.fetchBids(
+                {
+                    slots: amzn_buildSlotsArray(adInfo),
+                    timeout: 1000
+                },
+                function (bids) {
+                    pbjs.que.push(function () {
+                        googletag.cmd.push(function () {
+                            // Set Amazon bid key-values pairs
+                            try {
+                                apstag.setDisplayBids();
+                            } catch (e) {
+                                //do nothing
+                            }
+                        });
+                        bidderDone('a9', adInfo, adSlots);
+                    });
+                }
+            );
+        }
+
+        /* Prebid helper functions */
+        var prebid_fetchBids = function(adInfo, adSlots) {
+            var curAdIds = adInfo.map(function(e){return e.id;});
+            pbjs.que.push(function() {
+                pbjs.requestBids({
+                    timeout: PREBID_TIMEOUT,
+                    adUnitCodes: curAdIds,
+                    bidsBackHandler: function() {
+                        googletag.cmd.push(function() {
+                            pbjs.setTargetingForGPTAsync(curAdIds);
+                        });
+                        bidderDone('prebid', adInfo, adSlots);
+                    }
+                });
+            });
+        };
+
+        // ask bidders for their bids
+        requestBids(adInfo, adSlots);
+        // set timeout to send request to call sendAdserverRequest() after timeout
+        // it all bidders haven't returned before then
+        window.setTimeout(function() {
+            sendAdserverRequest(adInfo, adSlots);
+        }, bidTimeout);
+    }
+&lt;/script&gt;
+
+&lt;script&gt;
+    var buildAdUnits = function(adInfo) {
+        var adUnits = [];
+        var curUnit, curAdId, curAdType;
+        for(var i = 0; i &lt; adInfo.length; i++) {
+            curAdId = adInfo[i].id;
+            curAdType = adInfo[i].adType;
+            curUnit = {
+                code: curAdId,
+                mediaTypes: {
+                    banner: {
+                        sizes: amu_ads.adSlotConfig[curAdType].breakpoint.sizes
+                    }
+                },
+                bids: amu_ads.adSlotConfig[curAdType].breakpoint.bids
+            };
+            adUnits.push(curUnit);
+        }
+        return adUnits
+    };
+
+    var defineAds = function(adInfo) {
+        var slots = [];
+        var i, curSlot, curAdId, curAdType;
+        for (i = 0; i &lt; adInfo.length; i++) {
+            curAdId = adInfo[i].id;
+            curAdType = adInfo[i].adType;
+            // Define slot
+            curSlot = googletag.defineSlot(amu_ads.adSlotPath, amu_ads.adSlotConfig[curAdType].breakpoint.sizes, curAdId).addService(googletag.pubads());
+
+            // Set slot level targeting
+            for (key in amu_ads.adSlotConfig[curAdType].targeting) {
+                curSlot.setTargeting(key, amu_ads.adSlotConfig[curAdType].targeting[key]);
+            }
+
+            slots.push(curSlot);
+
+            // Store slot for later use (refreshing ads, etc)
+            amu_ads.adSlots[curAdId] = curSlot;
+
+        }
+        return slots;
+    };
+
+    var displayAds = function(adInfo) {
+        var curAdId;
+        if(adInfo.length === 0) {
+            googletag.display();
+        } else {
+            for(var i = 0; i &lt; adInfo.length; i++) {
+                curAdId = adInfo[i].id;
+                googletag.display(curAdId);
+            }
+        }
+    };
+
+    var refreshAds = function(adSlots) {
+        for(var i = 0; i &lt; adSlots.length; i++) {
+            adSlots[i].setTargeting('pv', getPageviewFromCookie());
+        }
+
+        if(adSlots.length === 0) {
+            googletag.pubads().refresh();
+        } else {
+            googletag.pubads().refresh(adSlots);
+        }
+    };
+
+    var auctionInit = function(adInfo, refresh) {
+        if(adInfo.length &gt; 0){
+            if(isEU) {
+                googletag.cmd.push(function() {
+                    // Define ads
+                    var adSlots = defineAds(adInfo);
+
+                    // Enable services for GPT
+                    googletag.enableServices();
+
+                    // Display Ads
+                    displayAds(adInfo);
+
+                    // Refresh bids
+                    refreshAds(adSlots);
+                });
+            } else {
+                pbjs.que.push(function() {
+                    googletag.cmd.push(function() {
+                        if(!refresh) {
+                            // Build ad units and add them to Prebid
+                            var adUnits = buildAdUnits(adInfo);
+                            pbjs.addAdUnits(adUnits);
+
+                            // Define ads
+                            var adSlots = defineAds(adInfo);
+
+                            // Enable services for GPT
+                            googletag.enableServices();
+                        } else {
+                            // Get existing ad slots
+                            var adSlots = adInfo.map(getAdSlot);
+                        }
+                        // Start header-bidding auction
+                        startAuction(1500, adInfo, adSlots, refresh);
+                    });
+                });
+            }
+        }
+    };
+
+    // Venatus
+    window.VM_API.push({
+        call: "is-consent-required",
+        onResult: function(res) {
+            //res = true in EU
+            //res = false outside EU
+            isEU = res;
+            if (document.readyState === "loading") {
+                document.addEventListener("DOMContentLoaded", function(event) {
+                    // Find ads
+                    var adElements = findAds('js-ad');
+
+                    // Get ad info
+                    var adInfo = getAdInfo(adElements);
+                    auctionInit(adInfo, false);
+
+                    //Lazy load ads
+                    adLazyLoaderInit('js-ad-lazy-load');
+
+                    // Refresh in view ads
+                    adRefresherInit('js-ad-refresh');
+                });
+            } else {
+                // Find ads
+                var adElements = findAds('js-ad');
+
+                // Get ad info
+                var adInfo = getAdInfo(adElements);
+
+                auctionInit(adInfo, false);
+
+                //Lazy load ads
+                adLazyLoaderInit('js-ad-lazy-load');
+
+                // Refresh ads in view
+                adRefresherInit('js-ad-refresh');
+            }
+        }
+    });
+
+&lt;/script&gt;
+
+
+&lt;!-- Sharethrough --&gt;
+&lt;script type="text/javascript" src="https://native.sharethrough.com/assets/sfp.js"&gt;&lt;/script&gt;
+
+  &lt;script src="/assets/application-313b7a6fafe9cac925824ccb4509a56f70853f175eb8361a4bda4d8669075081.js"&gt;&lt;/script&gt;
+  &lt;script src="/assets/packs/vendor-75451604b7930645e148.js"&gt;&lt;/script&gt;
+  &lt;script src="/assets/packs/application-60c6f4bcb5718ee7f628.js"&gt;&lt;/script&gt;
+
+  &lt;!-- Content Experiment JavaScript API client --&gt;
+&lt;script src="//www.google-analytics.com/cx/api.js?experiment=of4I6R6WTsCKu6PXpqZ_7w"&gt;&lt;/script&gt;
+
+&lt;script&gt;
+  // Ask Google Analytics which variation to show the visitor.
+  var chosenVariation = cxApi.chooseVariation();
+
+&lt;/script&gt;
+
+  &lt;script&gt;
+// Wait for the DOM to load, then execute the view for the chosen variation.
+
+uuExperimentInit = function(event) {
+
+  //if(chosenVariation === 0) {
+    // Variation 1 
+    // console.log('Experiment Version: Variation (B)');
+    // console.log('Google Response: ' + chosenVariation);
+    // $('.js-exp-original').addClass('hidden');
+    // $('.js-exp-variation').removeClass('hidden');
+  //} else {
+    // Original Variation
+    //console.log('Experiment Version: Original (A)');
+    //console.log('Google Response: ' + chosenVariation);
+    //$('.js-exp-variation').addClass('hidden');
+    //$('.js-exp-original').removeClass('hidden');
+  //}
+}
+
+$(document).ready(function() {
+  uuExperimentInit();
+});
+&lt;/script&gt;
+
+  &lt;link rel="alternate" type="application/atom+xml" title="ATOM" href="/feed" /&gt;
+  &lt;link rel="alternate" type="application/rss+xml" title="RSS" href="/feed.rss" /&gt;
+
+  &lt;!-- Begin comScore Tag --&gt;
+&lt;script&gt;
+    var _comscore = _comscore || [];
+    _comscore.push({ c1: "2", c2: "20519258" });
+    (function() {
+        var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+        s.src = (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js";
+        el.parentNode.insertBefore(s, el);
+    })();
+&lt;/script&gt;
+&lt;noscript&gt;
+  &lt;img src="http://b.scorecardresearch.com/p?c1=2&amp;c2=20519258&amp;cv=2.0&amp;cj=1" alt="" /&gt;
+&lt;/noscript&gt;
+&lt;!-- End comScore Tag --&gt;
+
+  &lt;script type="text/javascript"&gt;
+//Set markup and styling here
+window.cookieconsent_options = {
+  learnMore: 'More info',
+  link: '//andrewsmcmeel.com/privacy-policy',
+  //If you wish to use your own CSS instead, specify the URL of your CSS file. e.g. styles/my_custom_theme.css.
+  //This can be a relative or absolute URL.
+  //To stop Cookie Consent from loading CSS at all, specify false
+  //IE8 Styles need to be duplicated in app specific css overrides /assets/stylesheets/ie/ie8.css
+  theme: false,
+  markup: [
+    '&lt;div id="js-cookie-consent"&gt;',
+    '&lt;style type="text/css"&gt;.cc_banner-wrapper {height: 70px; } .cc_container {z-index:9001; position:fixed; width:100%; left:0; top:0; right:0; overflow:hidden; background-color:#666; } .cookie-choices-info {margin:0; padding:0; text-align:center; color:#fff; line-height:140%; padding:15px 0; font-family:roboto,Arial } .cookie-choices-info .cookie-choices-text {display:inline-block; vertical-align:middle; font-size:16px; margin:10px; color:#fefefe; max-width:800px; text-align:center } .cookie-choices-info .cookie-choices-buttons {display:inline-block; vertical-align:middle; white-space:nowrap; margin:10px } .cookie-choices-info .cookie-choices-button:hover {color:#fff; background-color:#000 } .cookie-choices-info .cookie-choices-button {background:#444; font-weight:700; text-transform:UPPERCASE; white-space:nowrap; color:#eee; margin-left:8px; padding:10px; border-radius:3px; text-decoration:none } @media screen and (max-width: 851px) {.cc_banner-wrapper {height:110px } } @media screen and (max-width: 588px) {.cc_banner-wrapper {height:140px } } @media screen and (max-width: 327px) {.cc_banner-wrapper {height:160px } } @media print {.cc_banner-wrapper,.cc_container {display:none } }&lt;/style&gt;',
+    '&lt;div class="cc_banner-wrapper {{containerClasses}}"&gt;',
+    '&lt;div class="cc_banner cc_container cc_container--open"&gt;',
+    '&lt;div class="cookie-choices-info"&gt;&lt;div class="cookie-choices-inner"&gt;&lt;span class="cookie-choices-text"&gt;{{options.message}}&lt;/span&gt;&lt;span class="cookie-choices-buttons"&gt; &lt;a data-cc-if="options.link" class="cookie-choices-button" target="_blank" href="//www.andrewsmcmeel.com/privacy-policy"&gt;{{options.learnMore}}&lt;/a&gt; &lt;a id="cookieChoiceDismiss" href="#null" data-cc-event="click:dismiss"  class="cookie-choices-button"&gt;{{options.dismiss}}&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;&lt;/div&gt;',
+    '&lt;/div&gt;',
+    '&lt;/div&gt;',
+    '&lt;/div&gt;'
+  ],
+  cookieName: 'dilbert_cookieconsent_dismissed',
+  readystate: 'interactive'
+};
+&lt;/script&gt;
+&lt;/head&gt;
+
+&lt;body class="layout-anchored" role="document"&gt;
+
+    &lt;!-- Google Universal Analytics Start --&gt;
+&lt;script&gt;
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  // UU Tracking Object
+  ga('create', "UA-273330-47", 'auto', {'name': 'trackerUU47'});
+  ga('trackerUU47.require', 'displayfeatures');
+  ga('trackerUU47.require', 'linkid');
+  ga('trackerUU47.require', 'outboundLinkTracker', {
+      shouldTrackOutboundLink: function(link) {
+          // Checks that the link's hostname does not contain "example.com".
+          return link.hostname.indexOf('dilbert.com') &lt; 0;
+      }
+  });
+  ga('trackerUU47.set', 'dimension1', "Dilbert Website");
+  ga('trackerUU47.set', 'dimension2', "Dilbert");
+  //ga(
+  //ga('.set'), 'dimension3', Subscribed to Newsletter);
+  //ga('.set'), 'dimension4', User - Blocking Ads);
+  //ga('.set'), 'dimension5', Pageview - Blocking Ads);
+  //ga('.set'), 'dimension6', Pageview - Ad Count);
+
+  ga('trackerUU47.send', 'pageview');
+
+  // Analytics Time Tracking
+  var trackTimeSpent = function(time) {
+    ga('trackerUU47.send', 'event', "Comics", "Dilbert", "");
+    //completionTime);
+  };
+
+  // Analytics Virtual Pageview Hit - Asynchronous View Change 
+  var trackItemsLoad = function(items) {
+    var currentPage = Math.round(parseInt(items - 1,10) / 3);
+    ga('trackerUU47.set', { "page": '' + currentPage, "title": "Dilbert - Page " + currentPage});
+    ga('trackerUU47.send', 'pageview');
+  };
+  
+  //Analytics Event Tracking - Sharing
+  var trackSharingToggle = function() {
+    ga('trackerUU47.send', 'event', 'social', 'Share - Activated Toggle');
+  };
+
+    var trackSharingToggle = function() {
+    ga('trackerUU47.send', 'event', 'social', 'Share - Activated Toggle');
+  };
+
+  // no longer used
+  var trackSharingCopiedLink = function() {
+    ga('trackerUU47.send', 'event', 'social', 'Share - Shared via Copied Link');
+  };
+
+  var trackSharingNetwork = function(network) {
+    ga('trackerUU47.send', 'event', 'social', 'Share - Shared via ' + network);
+  };
+  
+  var trackRating = function() {
+    ga('trackerUU47.send', 'event', 'social', 'UX - Comic Rated');
+  };
+  
+  var trackUXGeneric = function(trackingLabel) {
+    ga('trackerUU47.send', 'event', 'social', 'UX - ' + trackingLabel);
+  };
+
+  var trackFollow = function(trackingLabel) {
+    ga('trackerUU47.send', 'event', 'social', 'Follow - ' + trackingLabel);
+  };
+
+
+&lt;/script&gt;
+&lt;!-- Google Universal Analytics End --&gt;
+
+&lt;!-- Beginning of AMU Marketing Silverpop Tracking --&gt;
+&lt;meta name="com.silverpop.brandeddomains" content="www.pages02.net,ampkids.com,amureprints.com,andrewsmcmeel.com,calvinandhobbes.com,dilbert.com,epicbignate.com,gocomics.com,puzzlesociety.com,uexpress.com,wonderword.universaluclick.com" /&gt;
+&lt;!-- End of AMU Marketing Silverpop Tracking --&gt;
+
+    &lt;div class="container-fluid"&gt;
+        &lt;!-- HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START --&gt;
+&lt;div class="site-bg-bar"&gt;&lt;/div&gt;
+&lt;div class="container-header"&gt;
+  &lt;header class="site-header" role="banner"&gt;
+    &lt;div class="visible-xs-block site-mobile-header"&gt;
+      &lt;a class="btn btn-link site-header-mobile-link pull-left js-toggle-link" href="" data-target=".site-header-nav"&gt;&lt;i class="fa fa-bars fa-lg" aria-hidden="true"&gt;&lt;/i&gt;&lt;i class="fa fa-times fa-lg" aria-hidden="true"&gt;&lt;/i&gt; &lt;span class="sr-only"&gt;Menu&lt;/span&gt;&lt;/a&gt;
+      &lt;a href="" class="btn btn-link pull-right site-header-mobile-link js-toggle-link" data-target=".site-header-mobile-search"&gt;&lt;i class="fa fa-search fa-lg" aria-hidden="true"&gt;&lt;/i&gt;&lt;i class="fa fa-times fa-lg" aria-hidden="true"&gt;&lt;/i&gt; &lt;span class="sr-only"&gt;Search&lt;/span&gt;&lt;/a&gt;
+    &lt;/div&gt;
+    &lt;div class="site-header-branding"&gt;
+      &lt;span class="logo-container"&gt;&lt;a class="logo" title="Dilbert Logo" href="https://dilbert.com/"&gt;&lt;img src="/assets/dilbert-logo-b9a1fc1f44d5b72cb9eadcb5fa150087243ee83350dc600285879087887de0f0.png" alt="Dilbert logo" width="144" height="127" /&gt;&lt;/a&gt;&lt;/span&gt;
+      &lt;span class="hidden-xs"&gt;&lt;img class="characters-top" alt="" src="/assets/dilbert_character_top-8c372237e95037529b2eb865829ee93214d7575811f4a197b2ebe43966cda5fa.png" width="169" height="107" /&gt;&lt;/span&gt;
+    &lt;/div&gt;
+    &lt;!-- /.site-header-branding --&gt;
+    &lt;div class="site-header-nav hidden-xs"&gt;
+      &lt;nav role="navigation"&gt;
+        &lt;ul class="nav-main" role="menubar"&gt;
+          &lt;li role="menuitem" class="nav-main-item active"&gt;
+            &lt;a class="nav-main-link" href="https://dilbert.com/"&gt;Comics&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" class="nav-main-item "&gt;
+            &lt;a class="nav-main-link" href="http://blog.dilbert.com?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-engagement&amp;amp;utm_content=navigation"&gt;Blog&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" tabindex="-1" class="nav-main-item"&gt;&lt;a class="nav-main-link dropdown-toggle js-follow-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="#"&gt;Follow&lt;/a&gt;
+            &lt;ul role="menubar" class="dropdown-menu nav-main-dropdown"&gt;
+              &lt;li role="menuitem" class="nav-sub-item"&gt;&lt;a class="js-follow-facebook" href="https://www.facebook.com/dilbert?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-social&amp;amp;utm_content=navigation" target="_blank"&gt;&lt;i class="fa fa-fw fa-facebook"&gt;&lt;/i&gt; Facebook&lt;/a&gt;&lt;/li&gt;
+              &lt;li role="menuitem" class="nav-sub-item"&gt;&lt;a class="js-follow-twitter" href="https://twitter.com/Dilbert_Daily?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-social&amp;amp;utm_content=navigation" target="_blank"&gt;&lt;i class="fa fa-fw fa-twitter"&gt;&lt;/i&gt; Twitter&lt;/a&gt;&lt;/li&gt;
+              &lt;li role="menuitem" class="nav-sub-item"&gt;
+                &lt;a class="js-follow-comic-feed link-blended" target="_blank" href="http://feed.dilbert.com/dilbert/daily_strip"&gt;&lt;i class='fa fa-fw fa-rss'&gt;&lt;/i&gt; Comics&lt;/a&gt;&lt;/li&gt;
+              &lt;li role="menuitem" class="nav-sub-item"&gt;
+                &lt;a class="js-follow-blog-feed link-blended" href="http://feed.dilbert.com/dilbert/blog"&gt;&lt;i class='fa fa-fw fa-rss'&gt;&lt;/i&gt; Blog&lt;/a&gt;&lt;/li&gt;
+            &lt;/ul&gt;
+          &lt;/li&gt;
+          &lt;li role="search" class="nav-main-item "&gt;
+            &lt;a class="nav-main-link" href="/search"&gt;&lt;i class='fa fa-search'&gt;&lt;/i&gt; &lt;span class='sr-only'&gt;Search&lt;/span&gt;&lt;/a&gt;&lt;/li&gt;
+        &lt;/ul&gt;
+        &lt;ul class="nav-secondary" role="menubar"&gt;
+          &lt;li role="menuitem" class="nav-secondary-item"&gt;
+            &lt;a class="nav-secondary-link" href="http://blog.dilbert.com/about"&gt;About Dilbert&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" class="nav-secondary-item"&gt;
+            &lt;a class="nav-secondary-link" target="_blank" href="https://www.andrewsmcmeel.com/privacy-policy"&gt;Privacy&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" class="nav-secondary-item"&gt;
+            &lt;a class="nav-secondary-link" target="_blank" href="https://www.andrewsmcmeel.com/privacy-policy"&gt;Cookies&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" class="nav-secondary-item"&gt;
+            &lt;a class="nav-secondary-link" href="http://blog.dilbert.com/advertising"&gt;Advertising&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" class="nav-secondary-item"&gt;
+            &lt;a class="nav-secondary-link" href="http://blog.dilbert.com/contact"&gt;Contact&lt;/a&gt;
+          &lt;/li&gt;
+        &lt;/ul&gt;
+      &lt;/nav&gt;
+    &lt;/div&gt;
+    &lt;!-- /.site-header-nav --&gt;
+    &lt;div class="site-header-mobile-search"&gt;
+      &lt;form action="/search_results" method="get"&gt;
+        &lt;div class="form-group"&gt;
+          &lt;input type="text" name="terms" id="terms" class="form-control input-lg" placeholder="Search by Keyword or Date" /&gt;
+        &lt;/div&gt;
+        &lt;div class="form-group"&gt;
+          &lt;button name="" type="sumbit" class="btn btn-block btn-primary btn-lg"&gt;
+            &lt;i class='fa fa-search'&gt;&lt;/i&gt; Search
+&lt;/button&gt;        &lt;/div&gt;
+      &lt;/form&gt;
+    &lt;/div&gt;
+  &lt;/header&gt;
+  &lt;!-- /.site-header --&gt;
+&lt;/div&gt;
+&lt;!-- /.container-header --&gt;
+&lt;!-- HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END --&gt;
+          &lt;div class="ad-leaderboard" aria-hidden="true"&gt;
+    &lt;div id="leaderboard0" class="ad js-ad js-ad-refresh" data-ad-type="leaderboard"&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+        &lt;div class="page-wrapper content-section" role="main"&gt;
+	        
+&lt;div class="ad-anchored" aria-hidden="true"&gt;
+    &lt;div id="tower_anchored" class="ad js-ad js-ad-refresh" data-ad-type="tower_anchored"&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+&lt;h1 class="hidden" id="hidden-header"&gt;Dilbert.com by Scott Adams&lt;/h1&gt;
+
+&lt;script type='application/ld+json'&gt;
+{
+	"@context":"https://schema.org",
+	"@type":"WebSite",
+	"url":"https://www.dilbert.com",
+	"name":"Dilbert",
+	"logo":"http://dilbert.com/assets/dilbert-logo-b9a1fc1f44d5b72cb9eadcb5fa150087243ee83350dc600285879087887de0f0.png",
+	"potentialAction":{
+		"@type":"SearchAction",
+		"target":"https://www.dilbert.com/search_results?terms={search_term_string}",
+		"query-input":"required name=search_term_string"
+	},
+	"sameAs": [
+    	"https://www.facebook.com/dilbert",
+    	"https://twitter.com/Dilbert_Daily"
+  	]
+}
+&lt;/script&gt;
+
+&lt;div id="js_comics"&gt;
+    &lt;div class="js_comic_block_8339490"&gt;
+      
+&lt;div class="comic-item-container js_comic_container_2019-07-16"  accountablePerson="Andrews McMeel Syndication" creator="Scott Adams" data-itemtype="" data-id="2019-07-16" data-url="https://dilbert.com/strip/2019-07-16" data-image="//assets.amuniversal.com/c4d1b3a078c70137a69a005056a9545d" data-date="July 16, 2019" data-creator="Scott Adams" data-title="Phone Is More Interesting" data-tags="cell phone,criticism,date,dinner,entertainment,men and women,texting,smartphone" data-description="Tina:  I just realized I enjoy using my phone more than I enjoy interacting with you.  I mean, this thing is amazing, whereas you haven&amp;#39;t found a way to entertain me all night.
+Dilbert:  Maybe I&amp;#39;ll grow on you.
+Tina:  &amp;quot;Now he sounds like a tumor. LOl!&amp;quot;"&gt;
+  &lt;div class="meta-info-container"&gt;
+
+
+    &lt;section class="comic-item"&gt;
+
+      &lt;h1 class="comic-title"&gt;
+        &lt;a class="comic-title-link" href="https://dilbert.com/strip/2019-07-16"&gt;
+        &lt;span class="comic-date-wrapper"&gt;
+          &lt;date class="comic-title-date" itemProp="datePublished"&gt;
+            &lt;span&gt;Tuesday July 16,&lt;/span&gt;
+            &lt;span itemprop="copyrightYear"&gt;2019&lt;/span&gt;
+          &lt;/date&gt;
+        &lt;/span&gt;
+          &lt;span class="comic-title-name"&gt;Phone Is More Interesting&lt;/span&gt;
+        &lt;/a&gt;
+        &lt;span class="star-rating"&gt;
+          &lt;div class="star_rating_2019-07-16 js_star_rating star-rating" data-date="2019-07-16"&gt;&lt;/div&gt;
+        &lt;/span&gt;
+      &lt;/h1&gt;
+      &lt;div class="alert alert-success js_thanks_for_voting"&gt;
+          Thank you for voting.
+      &lt;/div&gt;
+
+      &lt;div class="img-comic-container"&gt;
+        &lt;a class="img-comic-link" href="https://dilbert.com/strip/2019-07-16" title="Click to see the comic strip Phone Is More Interesting"&gt;
+          &lt;img class="img-responsive img-comic" width="900" height="280" alt="Phone Is More Interesting - Dilbert by Scott Adams" src="//assets.amuniversal.com/c4d1b3a078c70137a69a005056a9545d" /&gt;
+        &lt;/a&gt;
+        &lt;meta itemprop="isFamilyFriendly" content="true"/&gt;
+
+        &lt;div data-src=".js_comic_container_2019-07-16" class="js-amu-social-section"&gt;
+          &lt;ul class="amu-section-social" role="toolbar"&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="email" class="social-btn social-btn-link js-email" href="mailto:?body=Check%20out%20this%20Dilbert%20Comic.%0D%0A%0D%0A%2F%2Fwww.dilbert.com%2Fstrip%2F2019-07-16%3Futm_source%3Ddilbert.com%2Fshare-email%26utm_medium%3Demail%26utm_campaign%3Dbrand-loyalty&amp;amp;subject=Dilbert%20by%20Scott%20Adams%2C%202019-07-16"&gt;
+                &lt;i class="fa fa-envelope fa-fw fa-lg"&gt;&lt;/i&gt; &lt;span class="sr-only"&gt;Email Comic&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="facebook" class="social-btn social-btn-facebook js-facebook share-btn" href="#"&gt;
+                &lt;i class="fa fa-facebook fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on Facebook&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="twitter" class="social-btn social-btn-twitter js-twitter share-btn" href="#"&gt;
+                &lt;i class="fa fa-twitter fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Tweet&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="linkedin" class="social-btn social-btn-linkedin js-linkedin share-btn" href="#"&gt;
+              &lt;i class="fa fa-linkedin fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on LinkedIn&lt;/span&gt;
+            &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;
+              &lt;a href="https://dilbert.com/strip/2019-07-16#comments" class="social-link" title="Join the discussion on Phone Is More Interesting Dilbert Comic Strip"&gt;
+                &lt;span class="social-link-icon"&gt;&lt;i class="fa fa-comments fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;
+                &lt;span class="social-label-stacked"&gt;
+                &lt;span class="social-label-top"&gt;Comments&lt;/span&gt;
+                &lt;span class="social-label-bottom disqus-comment-count" data-disqus-identifier="comic-2019-07-16"&gt;0&lt;/span&gt;
+              &lt;/span&gt;
+              &lt;/a&gt;
+            &lt;/li&gt;
+            &lt;li class="comic-buy-link amu-social-item"&gt;
+              &lt;a class="social-btn social-btn-link" href="/buy?date=2019-07-16" title="Purchase this strip"&gt;&lt;span class="visible-xs hidden-sm"&gt;&lt;i class="fa fa-shopping-cart fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class="hidden-xs"&gt;Buy&lt;/span&gt;&lt;/a&gt;
+            &lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/div&gt;
+
+
+        &lt;div id="js-toggle-element-2019-07-16" data-id="2019-07-16" class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;button type="button" class="close js-close-link" data-target="#js-toggle-element-2019-07-16"&gt;&lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;span class="sr-only"&gt;Close&lt;/span&gt;&lt;/button&gt;
+	&lt;h4 class="hdr-info"&gt;Share July 16, 2019's comic on:&lt;/h4&gt;
+	&lt;ul class="share-links list list-inline"&gt;
+		&lt;li&gt;&lt;a name="facebook" class="share-btn share-btn-facebook js-facebook" href="#"&gt;&lt;button class="fa fa-facebook fa-fw fa-lg" aria-label="Share on Facebook"&gt;&lt;/button&gt; Facebook&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="twitter" class="share-btn share-btn-twitter js-twitter" href="#"&gt;&lt;button class="fa fa-twitter fa-fw fa-lg" aria-label="Share on Twitter"&gt;&lt;/button&gt; Twitter&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="reddit" class="share-btn share-btn-reddit js-reddit" href="#"&gt;&lt;button class="fa fa-reddit fa-fw fa-lg" aria-label="Share on Reddit"&gt;&lt;/button&gt; Reddit&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="linkedin" class="share-btn share-btn-linkedin js-linkedin" href="#"&gt;&lt;button class="fa fa-linkedin fa-fw fa-lg" aria-label="Share on LinkedIn"&gt;&lt;/button&gt; LinkedIn&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;hr&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-16"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-16" value="https://dilbert.com/strip/2019-07-16"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+
+
+
+&lt;div id="js-toggle-element-2019-07-16-variation" data-id="2019-07-16"  class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-16"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-16" value="https://dilbert.com/strip/2019-07-16"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+        &lt;div class="meta-info-container"&gt;
+            &lt;p class="small comic-tags"&gt;
+              &lt;span class="label-sm"&gt;Tags&lt;/span&gt;
+                &lt;a class="link" href="/search_results?terms=cell+phone"&gt;#cell phone&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=criticism"&gt;#criticism&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=date"&gt;#date&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=dinner"&gt;#dinner&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=entertainment"&gt;#entertainment&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=men+and+women"&gt;#men and women&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=texting"&gt;#texting&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=smartphone"&gt;#smartphone&lt;/a&gt;
+            &lt;/p&gt;
+            &lt;p class="small"&gt;
+              &lt;a class="js-toggle-link " data-target="#js-toggle-transcript-2019-07-16" href=""&gt;View
+                Transcript&lt;/a&gt;
+            &lt;/p&gt;
+          &lt;div id="js-toggle-transcript-2019-07-16" class="js-toggle-container"&gt;
+            &lt;h4&gt;&lt;span class="label-sm"&gt;Transcript&lt;/span&gt;&lt;/h4&gt;
+            &lt;p&gt;Tina:  I just realized I enjoy using my phone more than I enjoy interacting with you.  I mean, this thing is amazing, whereas you haven&amp;#39;t found a way to entertain me all night.
+Dilbert:  Maybe I&amp;#39;ll grow on you.
+Tina:  &amp;quot;Now he sounds like a tumor. LOl!&amp;quot;&lt;/p&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/section&gt;
+  &lt;/div&gt;
+
+  &lt;script type="text/javascript"&gt;
+    $(function () {
+      $('.star_rating_2019-07-16').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+      $('.star_rating_2019-07-16').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+    });
+  &lt;/script&gt;
+
+&lt;/div&gt;
+
+
+    &lt;div class='shelf-space-container row js_shelf_ads'&gt;
+  &lt;div class="shelf-space-item"&gt;
+    &lt;div class="ad-rectangle" aria-hidden="true"&gt;
+    &lt;div id="rectangle0" class="ad js-ad js-ad-refresh" data-ad-type="rectangle"&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+  &lt;/div&gt;
+
+
+
+  &lt;div class="shelf-space-item"&gt;
+    &lt;h3 class="blog-hdr-top"&gt;&lt;a href="http://blog.dilbert.com?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-engagement&amp;amp;utm_content=shelf-space-2-blog"&gt;From Scott Adams&amp;#39; Blog&lt;/a&gt;&lt;/h3&gt;
+    &lt;div class="blog-item-multiple"&gt;
+      &lt;div class="media"&gt;
+        &lt;a class="link-blended" href="https://blog.dilbert.com/2019/07/15/episode-598-scott-adams-trumps-go-back-tweet-possible-iran-nuclear-deal/?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-engagement&amp;amp;utm_content=shelf-space-0-blog-title" title="Episode 598 Scott Adams: Trump’s “Go Back” Tweet, Possible Iran Nuclear Deal by Scott Adams"&gt;
+          &lt;div class="media-left"&gt;
+              &lt;img class="media-object" alt="" src="/assets/avatar_scottadams_128-751be3ae01272f9b970ccc9a004a02d35f13538a873d0d055371657ddfc1ab31.png" width="64" height="64" /&gt;
+          &lt;/div&gt;
+          &lt;div class="media-body"&gt;
+            &lt;h4 class="media-heading"&gt;Episode 598 Scott Adams: Trump’s “Go Back” Tweet, Possible Iran Nuclear Deal&lt;/h4&gt;
+            &lt;span class="blog-author"&gt;by Scott Adams&lt;/span&gt;
+          &lt;/div&gt;
+        &lt;/a&gt;
+      &lt;/div&gt;
+
+
+      &lt;div class="media"&gt;
+        &lt;a class="link-blended" href="https://blog.dilbert.com/2019/07/14/episode-597-scott-adams-bubonic-plague-mind-reading-british-diplomats-chat-with-carpedonktum/?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-engagement&amp;amp;utm_content=shelf-space-0-blog-title" title="Episode 597 Scott Adams: Bubonic Plague, Mind-Reading British Diplomats, Chat With @CarpeDonktum by Scott Adams"&gt;
+          &lt;div class="media-left"&gt;
+              &lt;img class="media-object" alt="" src="/assets/avatar_scottadams_128-751be3ae01272f9b970ccc9a004a02d35f13538a873d0d055371657ddfc1ab31.png" width="64" height="64" /&gt;
+          &lt;/div&gt;
+          &lt;div class="media-body"&gt;
+            &lt;h4 class="media-heading"&gt;Episode 597 Scott Adams: Bubonic Plague, Mind-Reading British Diplomats, Chat With @CarpeDonktum&lt;/h4&gt;
+            &lt;span class="blog-author"&gt;by Scott Adams&lt;/span&gt;
+          &lt;/div&gt;
+        &lt;/a&gt;
+      &lt;/div&gt;
+
+      
+      &lt;div class="media"&gt;
+        &lt;a class="link-blended" href="https://blog.dilbert.com/2019/07/13/episode-596-scott-adams-vp-pence-visits-border-kanye-building-homes-audience-questions/?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-engagement&amp;amp;utm_content=shelf-space-0-blog-title" title="Episode 596 Scott Adams: VP Pence Visits Border, Kanye Building Homes, Audience Questions by Scott Adams"&gt;
+          &lt;div class="media-left"&gt;
+              &lt;img class="media-object" alt="" src="/assets/avatar_scottadams_128-751be3ae01272f9b970ccc9a004a02d35f13538a873d0d055371657ddfc1ab31.png" width="64" height="64" /&gt;
+          &lt;/div&gt;
+          &lt;div class="media-body"&gt;
+            &lt;h4 class="media-heading"&gt;Episode 596 Scott Adams: VP Pence Visits Border, Kanye Building Homes, Audience Questions&lt;/h4&gt;
+            &lt;span class="blog-author"&gt;by Scott Adams&lt;/span&gt;
+          &lt;/div&gt;
+        &lt;/a&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+
+
+
+  &lt;div class="shelf-space-item shelf-space-item-right"&gt;
+    &lt;div class="ad-rectangle-right" aria-hidden="true"&gt;
+    &lt;div id="rectangle_right0" class="ad js-ad js-ad-refresh" data-ad-type="rectangle_right"&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+
+
+
+
+      
+&lt;div class="comic-item-container js_comic_container_2019-07-15"  accountablePerson="Andrews McMeel Syndication" creator="Scott Adams" data-itemtype="" data-id="2019-07-15" data-url="https://dilbert.com/strip/2019-07-15" data-image="//assets.amuniversal.com/989e6c2078c50137a69a005056a9545d" data-date="July 15, 2019" data-creator="Scott Adams" data-title="More People Working At Home" data-tags="boss,employees,office,office workers" data-description="Boss:  The office is too quiet today.
+Carol:  That&amp;#39;s because more people are working from home.
+Boss:  How can I do my job if I can&amp;#39;t pop into people&amp;#39;s cubicles and share my wisdom?  Second question: why is everything running so smoothly lately?"&gt;
+  &lt;div class="meta-info-container"&gt;
+
+
+    &lt;section class="comic-item"&gt;
+
+      &lt;h1 class="comic-title"&gt;
+        &lt;a class="comic-title-link" href="https://dilbert.com/strip/2019-07-15"&gt;
+        &lt;span class="comic-date-wrapper"&gt;
+          &lt;date class="comic-title-date" itemProp="datePublished"&gt;
+            &lt;span&gt;Monday July 15,&lt;/span&gt;
+            &lt;span itemprop="copyrightYear"&gt;2019&lt;/span&gt;
+          &lt;/date&gt;
+        &lt;/span&gt;
+          &lt;span class="comic-title-name"&gt;More People Working At Home&lt;/span&gt;
+        &lt;/a&gt;
+        &lt;span class="star-rating"&gt;
+          &lt;div class="star_rating_2019-07-15 js_star_rating star-rating" data-date="2019-07-15"&gt;&lt;/div&gt;
+        &lt;/span&gt;
+      &lt;/h1&gt;
+      &lt;div class="alert alert-success js_thanks_for_voting"&gt;
+          Thank you for voting.
+      &lt;/div&gt;
+
+      &lt;div class="img-comic-container"&gt;
+        &lt;a class="img-comic-link" href="https://dilbert.com/strip/2019-07-15" title="Click to see the comic strip More People Working At Home"&gt;
+          &lt;img class="img-responsive img-comic" width="900" height="280" alt="More People Working At Home - Dilbert by Scott Adams" src="//assets.amuniversal.com/989e6c2078c50137a69a005056a9545d" /&gt;
+        &lt;/a&gt;
+        &lt;meta itemprop="isFamilyFriendly" content="true"/&gt;
+
+        &lt;div data-src=".js_comic_container_2019-07-15" class="js-amu-social-section"&gt;
+          &lt;ul class="amu-section-social" role="toolbar"&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="email" class="social-btn social-btn-link js-email" href="mailto:?body=Check%20out%20this%20Dilbert%20Comic.%0D%0A%0D%0A%2F%2Fwww.dilbert.com%2Fstrip%2F2019-07-15%3Futm_source%3Ddilbert.com%2Fshare-email%26utm_medium%3Demail%26utm_campaign%3Dbrand-loyalty&amp;amp;subject=Dilbert%20by%20Scott%20Adams%2C%202019-07-15"&gt;
+                &lt;i class="fa fa-envelope fa-fw fa-lg"&gt;&lt;/i&gt; &lt;span class="sr-only"&gt;Email Comic&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="facebook" class="social-btn social-btn-facebook js-facebook share-btn" href="#"&gt;
+                &lt;i class="fa fa-facebook fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on Facebook&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="twitter" class="social-btn social-btn-twitter js-twitter share-btn" href="#"&gt;
+                &lt;i class="fa fa-twitter fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Tweet&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="linkedin" class="social-btn social-btn-linkedin js-linkedin share-btn" href="#"&gt;
+              &lt;i class="fa fa-linkedin fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on LinkedIn&lt;/span&gt;
+            &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;
+              &lt;a href="https://dilbert.com/strip/2019-07-15#comments" class="social-link" title="Join the discussion on More People Working At Home Dilbert Comic Strip"&gt;
+                &lt;span class="social-link-icon"&gt;&lt;i class="fa fa-comments fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;
+                &lt;span class="social-label-stacked"&gt;
+                &lt;span class="social-label-top"&gt;Comments&lt;/span&gt;
+                &lt;span class="social-label-bottom disqus-comment-count" data-disqus-identifier="comic-2019-07-15"&gt;0&lt;/span&gt;
+              &lt;/span&gt;
+              &lt;/a&gt;
+            &lt;/li&gt;
+            &lt;li class="comic-buy-link amu-social-item"&gt;
+              &lt;a class="social-btn social-btn-link" href="/buy?date=2019-07-15" title="Purchase this strip"&gt;&lt;span class="visible-xs hidden-sm"&gt;&lt;i class="fa fa-shopping-cart fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class="hidden-xs"&gt;Buy&lt;/span&gt;&lt;/a&gt;
+            &lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/div&gt;
+
+
+        &lt;div id="js-toggle-element-2019-07-15" data-id="2019-07-15" class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;button type="button" class="close js-close-link" data-target="#js-toggle-element-2019-07-15"&gt;&lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;span class="sr-only"&gt;Close&lt;/span&gt;&lt;/button&gt;
+	&lt;h4 class="hdr-info"&gt;Share July 15, 2019's comic on:&lt;/h4&gt;
+	&lt;ul class="share-links list list-inline"&gt;
+		&lt;li&gt;&lt;a name="facebook" class="share-btn share-btn-facebook js-facebook" href="#"&gt;&lt;button class="fa fa-facebook fa-fw fa-lg" aria-label="Share on Facebook"&gt;&lt;/button&gt; Facebook&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="twitter" class="share-btn share-btn-twitter js-twitter" href="#"&gt;&lt;button class="fa fa-twitter fa-fw fa-lg" aria-label="Share on Twitter"&gt;&lt;/button&gt; Twitter&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="reddit" class="share-btn share-btn-reddit js-reddit" href="#"&gt;&lt;button class="fa fa-reddit fa-fw fa-lg" aria-label="Share on Reddit"&gt;&lt;/button&gt; Reddit&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="linkedin" class="share-btn share-btn-linkedin js-linkedin" href="#"&gt;&lt;button class="fa fa-linkedin fa-fw fa-lg" aria-label="Share on LinkedIn"&gt;&lt;/button&gt; LinkedIn&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;hr&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-15"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-15" value="https://dilbert.com/strip/2019-07-15"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+
+
+
+&lt;div id="js-toggle-element-2019-07-15-variation" data-id="2019-07-15"  class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-15"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-15" value="https://dilbert.com/strip/2019-07-15"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+        &lt;div class="meta-info-container"&gt;
+            &lt;p class="small comic-tags"&gt;
+              &lt;span class="label-sm"&gt;Tags&lt;/span&gt;
+                &lt;a class="link" href="/search_results?terms=boss"&gt;#boss&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=employees"&gt;#employees&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=office"&gt;#office&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=office+workers"&gt;#office workers&lt;/a&gt;
+            &lt;/p&gt;
+            &lt;p class="small"&gt;
+              &lt;a class="js-toggle-link " data-target="#js-toggle-transcript-2019-07-15" href=""&gt;View
+                Transcript&lt;/a&gt;
+            &lt;/p&gt;
+          &lt;div id="js-toggle-transcript-2019-07-15" class="js-toggle-container"&gt;
+            &lt;h4&gt;&lt;span class="label-sm"&gt;Transcript&lt;/span&gt;&lt;/h4&gt;
+            &lt;p&gt;Boss:  The office is too quiet today.
+Carol:  That&amp;#39;s because more people are working from home.
+Boss:  How can I do my job if I can&amp;#39;t pop into people&amp;#39;s cubicles and share my wisdom?  Second question: why is everything running so smoothly lately?&lt;/p&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/section&gt;
+  &lt;/div&gt;
+
+  &lt;script type="text/javascript"&gt;
+    $(function () {
+      $('.star_rating_2019-07-15').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+      $('.star_rating_2019-07-15').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+    });
+  &lt;/script&gt;
+
+&lt;/div&gt;
+
+
+
+
+      
+&lt;div class="comic-item-container js_comic_container_2019-07-14"  accountablePerson="Andrews McMeel Syndication" creator="Scott Adams" data-itemtype="" data-id="2019-07-14" data-url="https://dilbert.com/strip/2019-07-14" data-image="//assets.amuniversal.com/3f5c29a05f0f01379d9a005056a9545d" data-date="July 14, 2019" data-creator="Scott Adams" data-title="Finding A Scapegoat" data-tags="business,office,project,ceo,scapegaot,climate change" data-description="the boss: we&amp;#39;ll need a scapegoat to blame for our failure on this project.
+dilbert: no one will believe it wasn&amp;#39;t our fault.
+the boss: are you kidding?
+the boss: people will believe anything.
+the boss: we just have to be the first to frame the situation.
+dilbert: i suppose we could make our lie sound credible.
+the boss: that&amp;#39;s overkill.
+dilbert: we don&amp;#39;t need to sound credible?
+ the boss: not even a little.
+the boss is in ceo&amp;#39;s office.
+the boss: our project failed because of climate change.
+ceo: that sounds right."&gt;
+  &lt;div class="meta-info-container"&gt;
+
+
+    &lt;section class="comic-item"&gt;
+
+      &lt;h1 class="comic-title"&gt;
+        &lt;a class="comic-title-link" href="https://dilbert.com/strip/2019-07-14"&gt;
+        &lt;span class="comic-date-wrapper"&gt;
+          &lt;date class="comic-title-date" itemProp="datePublished"&gt;
+            &lt;span&gt;Sunday July 14,&lt;/span&gt;
+            &lt;span itemprop="copyrightYear"&gt;2019&lt;/span&gt;
+          &lt;/date&gt;
+        &lt;/span&gt;
+          &lt;span class="comic-title-name"&gt;Finding A Scapegoat&lt;/span&gt;
+        &lt;/a&gt;
+        &lt;span class="star-rating"&gt;
+          &lt;div class="star_rating_2019-07-14 js_star_rating star-rating" data-date="2019-07-14"&gt;&lt;/div&gt;
+        &lt;/span&gt;
+      &lt;/h1&gt;
+      &lt;div class="alert alert-success js_thanks_for_voting"&gt;
+          Thank you for voting.
+      &lt;/div&gt;
+
+      &lt;div class="img-comic-container"&gt;
+        &lt;a class="img-comic-link" href="https://dilbert.com/strip/2019-07-14" title="Click to see the comic strip Finding A Scapegoat"&gt;
+          &lt;img class="img-responsive img-comic" width="900" height="439" alt="Finding A Scapegoat - Dilbert by Scott Adams" src="//assets.amuniversal.com/3f5c29a05f0f01379d9a005056a9545d" /&gt;
+        &lt;/a&gt;
+        &lt;meta itemprop="isFamilyFriendly" content="true"/&gt;
+
+        &lt;div data-src=".js_comic_container_2019-07-14" class="js-amu-social-section"&gt;
+          &lt;ul class="amu-section-social" role="toolbar"&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="email" class="social-btn social-btn-link js-email" href="mailto:?body=Check%20out%20this%20Dilbert%20Comic.%0D%0A%0D%0A%2F%2Fwww.dilbert.com%2Fstrip%2F2019-07-14%3Futm_source%3Ddilbert.com%2Fshare-email%26utm_medium%3Demail%26utm_campaign%3Dbrand-loyalty&amp;amp;subject=Dilbert%20by%20Scott%20Adams%2C%202019-07-14"&gt;
+                &lt;i class="fa fa-envelope fa-fw fa-lg"&gt;&lt;/i&gt; &lt;span class="sr-only"&gt;Email Comic&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="facebook" class="social-btn social-btn-facebook js-facebook share-btn" href="#"&gt;
+                &lt;i class="fa fa-facebook fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on Facebook&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="twitter" class="social-btn social-btn-twitter js-twitter share-btn" href="#"&gt;
+                &lt;i class="fa fa-twitter fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Tweet&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="linkedin" class="social-btn social-btn-linkedin js-linkedin share-btn" href="#"&gt;
+              &lt;i class="fa fa-linkedin fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on LinkedIn&lt;/span&gt;
+            &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;
+              &lt;a href="https://dilbert.com/strip/2019-07-14#comments" class="social-link" title="Join the discussion on Finding A Scapegoat Dilbert Comic Strip"&gt;
+                &lt;span class="social-link-icon"&gt;&lt;i class="fa fa-comments fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;
+                &lt;span class="social-label-stacked"&gt;
+                &lt;span class="social-label-top"&gt;Comments&lt;/span&gt;
+                &lt;span class="social-label-bottom disqus-comment-count" data-disqus-identifier="comic-2019-07-14"&gt;0&lt;/span&gt;
+              &lt;/span&gt;
+              &lt;/a&gt;
+            &lt;/li&gt;
+            &lt;li class="comic-buy-link amu-social-item"&gt;
+              &lt;a class="social-btn social-btn-link" href="/buy?date=2019-07-14" title="Purchase this strip"&gt;&lt;span class="visible-xs hidden-sm"&gt;&lt;i class="fa fa-shopping-cart fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class="hidden-xs"&gt;Buy&lt;/span&gt;&lt;/a&gt;
+            &lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/div&gt;
+
+
+        &lt;div id="js-toggle-element-2019-07-14" data-id="2019-07-14" class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;button type="button" class="close js-close-link" data-target="#js-toggle-element-2019-07-14"&gt;&lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;span class="sr-only"&gt;Close&lt;/span&gt;&lt;/button&gt;
+	&lt;h4 class="hdr-info"&gt;Share July 14, 2019's comic on:&lt;/h4&gt;
+	&lt;ul class="share-links list list-inline"&gt;
+		&lt;li&gt;&lt;a name="facebook" class="share-btn share-btn-facebook js-facebook" href="#"&gt;&lt;button class="fa fa-facebook fa-fw fa-lg" aria-label="Share on Facebook"&gt;&lt;/button&gt; Facebook&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="twitter" class="share-btn share-btn-twitter js-twitter" href="#"&gt;&lt;button class="fa fa-twitter fa-fw fa-lg" aria-label="Share on Twitter"&gt;&lt;/button&gt; Twitter&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="reddit" class="share-btn share-btn-reddit js-reddit" href="#"&gt;&lt;button class="fa fa-reddit fa-fw fa-lg" aria-label="Share on Reddit"&gt;&lt;/button&gt; Reddit&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="linkedin" class="share-btn share-btn-linkedin js-linkedin" href="#"&gt;&lt;button class="fa fa-linkedin fa-fw fa-lg" aria-label="Share on LinkedIn"&gt;&lt;/button&gt; LinkedIn&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;hr&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-14"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-14" value="https://dilbert.com/strip/2019-07-14"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+
+
+
+&lt;div id="js-toggle-element-2019-07-14-variation" data-id="2019-07-14"  class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-14"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-14" value="https://dilbert.com/strip/2019-07-14"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+        &lt;div class="meta-info-container"&gt;
+            &lt;p class="small comic-tags"&gt;
+              &lt;span class="label-sm"&gt;Tags&lt;/span&gt;
+                &lt;a class="link" href="/search_results?terms=business"&gt;#business&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=office"&gt;#office&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=project"&gt;#project&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=ceo"&gt;#ceo&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=scapegaot"&gt;#scapegaot&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=climate+change"&gt;#climate change&lt;/a&gt;
+            &lt;/p&gt;
+            &lt;p class="small"&gt;
+              &lt;a class="js-toggle-link " data-target="#js-toggle-transcript-2019-07-14" href=""&gt;View
+                Transcript&lt;/a&gt;
+            &lt;/p&gt;
+          &lt;div id="js-toggle-transcript-2019-07-14" class="js-toggle-container"&gt;
+            &lt;h4&gt;&lt;span class="label-sm"&gt;Transcript&lt;/span&gt;&lt;/h4&gt;
+            &lt;p&gt;the boss: we&amp;#39;ll need a scapegoat to blame for our failure on this project.
+dilbert: no one will believe it wasn&amp;#39;t our fault.
+the boss: are you kidding?
+the boss: people will believe anything.
+the boss: we just have to be the first to frame the situation.
+dilbert: i suppose we could make our lie sound credible.
+the boss: that&amp;#39;s overkill.
+dilbert: we don&amp;#39;t need to sound credible?
+ the boss: not even a little.
+the boss is in ceo&amp;#39;s office.
+the boss: our project failed because of climate change.
+ceo: that sounds right.&lt;/p&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/section&gt;
+  &lt;/div&gt;
+
+  &lt;script type="text/javascript"&gt;
+    $(function () {
+      $('.star_rating_2019-07-14').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+      $('.star_rating_2019-07-14').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+    });
+  &lt;/script&gt;
+
+&lt;/div&gt;
+
+
+    &lt;div class="ad-banner" aria-hidden="true"&gt;
+    &lt;div id="banner0" class="ad js-ad-lazy-load js-ad-refresh" data-ad-type="banner"&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+
+
+  &lt;/div&gt;
+  
+
+&lt;/div&gt;
+
+&lt;div id="infinite-scrolling" class="infinite-scrolling-container"&gt;
+  &lt;a class="js_load_comics pagination" href="/?post_index=3&amp;amp;series_count=0&amp;amp;starting_point=3"&gt;&lt;p&gt;&lt;i class="fa fa-refresh fa-2x"&gt;&lt;/i&gt;&lt;/p&gt;&lt;p class="text-muted js-load-comics-text"&gt;Load More&lt;/p&gt;&lt;/a&gt;
+&lt;/div&gt;
+
+&lt;script src="/assets/disqus-aaccaa13d7722a7ec0b3053e511b0517ac8cb350ddb93548954dee6c6d1215ce.js"&gt;&lt;/script&gt;
+
+        &lt;/div&gt;
+    &lt;/div&gt;
+
+    &lt;div class="ad-locked" aria-hidden="true"&gt;
+  &lt;div id="tynt" class="js-ad" data-ad-type="tynt"&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+    &lt;div class="ad-venatus" aria-hidden="true"&gt;
+  &lt;div id="venatus" class="js-ad" data-ad-type="venatus"&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+    &lt;!-- Quantcast Tag --&gt;
+&lt;script type="text/javascript"&gt;
+    var _qevents = _qevents || [];
+
+    (function() {
+        var elem = document.createElement('script');
+        elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+        elem.async = true;
+        elem.type = "text/javascript";
+        var scpt = document.getElementsByTagName('script')[0];
+        scpt.parentNode.insertBefore(elem, scpt);
+    })();
+
+    _qevents.push({
+        qacct:"p-5bhew76JBcfq6"
+    });
+&lt;/script&gt;
+
+&lt;noscript&gt;
+  &lt;div style="display:none;"&gt;
+    &lt;img src="//pixel.quantserve.com/pixel/p-5bhew76JBcfq6.gif" border="0" height="1" width="1" alt=""/&gt;
+  &lt;/div&gt;
+&lt;/noscript&gt;
+&lt;!-- End Quantcast tag --&gt;
+
+    &lt;script src="/assets/apollo-759f6f2ba681ee0e19fb93c9b53715806430656f53154427bc5eb3e1560bf28a.js?sampling=2&amp;tracker=trackerUU47"&gt;&lt;/script&gt;
+&lt;/body&gt;
+&lt;/html&gt;
+</ReturnValue>
+    <OutAndRefValues />
+  </RecordedCall>
+</ArrayOfRecordedCall>

--- a/tests/SendComics.IntegrationTests/RecordedCalls/TwoSubscribersOneCommentedOut_BuildsOneMailForNonCommented.xml
+++ b/tests/SendComics.IntegrationTests/RecordedCalls/TwoSubscribersOneCommentedOut_BuildsOneMailForNonCommented.xml
@@ -1,0 +1,4176 @@
+<?xml version="1.0"?>
+<ArrayOfRecordedCall xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <RecordedCall>
+    <Method>System.String GetContent(System.Uri)</Method>
+    <ReturnValue xsi:type="xsd:string">&lt;!DOCTYPE html&gt;
+&lt;html lang="en"&gt;
+  &lt;head&gt;
+      &lt;title&gt;9 Chickweed Lane by Brooke McEldowney for July 16, 2019 - GoComics&lt;/title&gt;
+
+      &lt;!--- MOBILE SCALE --&gt;
+  &lt;meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5.0, minimum-scale=1, user-scalable=yes"/&gt;
+	&lt;meta http-equiv="cleartype" content="on" /&gt;
+	&lt;meta http-equiv="Content-type" content="text/html;charset=UTF-8"&gt;
+	&lt;meta name='HandheldFriendly' content='True' /&gt;
+	&lt;meta name='MobileOptimized' content='320' /&gt;
+  
+  &lt;meta name="csrf-param" content="authenticity_token" /&gt;
+&lt;meta name="csrf-token" content="x+IUY32YD0KIgEhSqwuwASkH/hWbkuomsKKWhIXIIUfBFBWdcyVutaDsOKR8BIcBrr5JG8XBKHRJJS5e0wnJZQ==" /&gt;
+
+      &lt;link rel="canonical" href="https://www.gocomics.com/9chickweedlane/2019/07/16"&gt;    &lt;!-- Dynamic General Tags --&gt;
+&lt;!-- &lt;link rel="image_src" href="" /&gt; --&gt;
+&lt;meta name="keywords" content="9 Chickweed Lane July 16, 2019, Comic Strip for 9 Chickweed Lane, 9 Chickweed Lane, Cartoonist Brooke McEldowney, 9 Chickweed Lane GoComics, Comics, editorial cartoons, email comics, comic strips" /&gt;
+&lt;meta name="description" content="View the comic strip for 9 Chickweed Lane by cartoonist Brooke McEldowney created July 16, 2019 available on GoComics.com" /&gt;
+
+&lt;!-- Feature Item Sharing --&gt;
+&lt;!-- Facebook Open Graph Tags --&gt;
+&lt;meta property="og:url" content="https://www.gocomics.com/9chickweedlane/2019/07/16" /&gt;
+&lt;meta property="og:type" content="article" /&gt;
+&lt;meta property="og:title" content="9 Chickweed Lane by Brooke McEldowney for July 16, 2019 | GoComics.com" /&gt;
+&lt;meta property="og:image" content="https://assets.amuniversal.com/d4571e307e420137a88c005056a9545d" /&gt;
+&lt;meta property="og:image:height" content="282" /&gt;
+&lt;meta property="og:image:width" content="900" /&gt;
+&lt;meta property="og:description" content="" /&gt;
+&lt;meta property="og:site_name" content="GoComics" /&gt;
+&lt;meta property="fb:app_id" content="1747171135497727" /&gt;
+
+&lt;!-- Dynamic Twitter Card Meta Tags --&gt;
+&lt;meta name="twitter:card" content="photo"&gt;
+&lt;meta name="twitter:site" content="@GoComics"&gt;
+&lt;meta name="twitter:url" content="https://www.gocomics.com/9chickweedlane/2019/07/16"&gt;
+&lt;meta name="twitter:title" content="9 Chickweed Lane by Brooke McEldowney for July 16, 2019 | GoComics.com"&gt;
+&lt;meta name="twitter:description" content="July 16, 2019"&gt;
+&lt;meta name="twitter:image" content="https://assets.amuniversal.com/d4571e307e420137a88c005056a9545d"&gt;
+
+&lt;!-- Other OG Tags --&gt;
+&lt;meta property="article:published_time" content="2019-07-16" /&gt;
+&lt;meta property="article:author" content="Brooke McEldowney" /&gt;
+&lt;meta property="article:section" content="comic" /&gt;
+&lt;meta property="article:tag" content="" /&gt;
+
+
+  &lt;!-- Pinterest Verification --&gt;
+  &lt;meta name="p:domain_verify" content="2daa671e72ed57aab721dcad175fc876"/&gt;
+
+  &lt;!-- Webmaster Verification Tag --&gt;
+  &lt;meta name="msvalidate.01" content="CA2B093E89A42FE68A7281E53F12B64D" /&gt;
+  &lt;meta name="google-site-verification" content="iggzxjEv3099Ou5--yot5AOC_AcxqiS1g8kCGLfpSi8" /&gt;
+    	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-57x57-5f4787a1e81ece88fd748a38920a8490ba30c4c1765bb4c3a5fe8ac6d3b23d52.png" sizes="57x57" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-60x60-66c17bfd7a2544bc1d56606fffecd4b9e21bea4cfd1158eea09b873bd9ba9e8f.png" sizes="60x60" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-72x72-7b079675c10869aa5106bc43c97fd51dcd9704e7a728b0927e59a3fa9d7984ee.png" sizes="72x72" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-76x76-fde94b7ab5a5241b10f972616eecc506dca67803d2b41c8656661782cb5a20bf.png" sizes="76x76" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-114x114-1b749de56e3cb177db872794312fb2c8f78d75cdd8b44c81e0a8583f37d9e834.png" sizes="114x114" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-120x120-e0491d8c956f38a60431f0545d71d35f3acb7bdf58498d6f34a51c92d59a870d.png" sizes="120x120" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-144x144-5a7d4892325d4c929dc8b809c95d36ed2bfde766956e33f4afb73074bf6edfdb.png" sizes="144x144" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-152x152-12d6d62e9635b25ed3d0c31a35e7d8c2249c3ae239aee23dcba5cd908da0ef69.png" sizes="152x152" /&gt;
+	&lt;link rel="apple-icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/apple-icon-180x180-db8274b4743e90bff418f28febaf069fca79df4c809d6fe25bc0402078d6c0ea.png" sizes="180x180" /&gt;
+	&lt;link rel="icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/favicon-32x32-224453efe388a04d04596959b7d54d52dd64143ab36a1e967af5fc506637b71f.png" sizes="32x32" /&gt;
+	&lt;link rel="icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/favicon-96x96-92f1ac367fd0f34bc17956ef33d79433ddbec62144ee17b40add7a6a2ae6e61a.png" sizes="96x96" /&gt;
+	&lt;link rel="icon" type="image/png" href="https://assets.gocomics.com/assets/favicons/favicon-16x16-6b66b8ce06776f4bfd528fef18b1345758f780a4d5c60edc6ddf02151721d3f4.png" sizes="16x16" /&gt;
+	&lt;link rel="manifest" href="https://assets.gocomics.com/assets/favicons/manifest-27eca3e8297eb7ff340deb3849b210185a459b3845456aa4d0036f6d966b3518.json" /&gt;
+	&lt;meta name="msapplication-TileColor" content="#ffffff" /&gt;
+	&lt;meta name="msapplication-TileImage" content="https://assets.gocomics.com/assets/favicons/ms-icon-144x144-5a7d4892325d4c929dc8b809c95d36ed2bfde766956e33f4afb73074bf6edfdb.png" /&gt;
+	&lt;meta name="theme-color" content="#ffffff" /&gt;
+    &lt;link rel="stylesheet" media="all" href="https://assets.gocomics.com/assets/application-gc-1d140142105c4833d80f665b09c6c6817b3304d00e6d48853069008a417036be.css" /&gt;
+    &lt;script src="https://assets.gocomics.com/assets/application-gc-preload-590b2dbef8d985bc4f074211bf82ace762630acac84c3bf0809b8d58017d64fa.js"&gt;&lt;/script&gt;
+
+    &lt;!-- Confiant --&gt;
+&lt;script async="" src="https://confiant-integrations.global.ssl.fastly.net/URCY_lYNAEeMRZShS4CoaDXuIew/gpt_and_prebid/config.js"&gt;&lt;/script&gt;
+
+&lt;!-- Prebid Wrapper --&gt;
+&lt;script src="https://assets.gocomics.com/assets/ad-dependencies-bac6f666726b60bf0d10ac1a15b24a0faab86db58c7dbc154274d8868c767982.js"&gt;&lt;/script&gt;
+
+&lt;!-- Venatus Market Ad-Manager (gocomics.com) --&gt;
+&lt;script&gt;
+    (function(){document.write('&lt;div id="vmv3-ad-manager" style="display:none"&gt;&lt;/div&gt;');document.getElementById("vmv3-ad-manager").innerHTML='&lt;iframe id="vmv3-frm" src="javascript:\'&lt;html&gt;&lt;body&gt;&lt;/body&gt;&lt;/html&gt;\'" width="0" height="0" data-mode="scan" data-site-id="5b04343a46e0fb0001162107"&gt;&lt;/iframe&gt;';var a=document.getElementById("vmv3-frm");a=a.contentWindow?a.contentWindow:a.contentDocument;a.document.open();a.document.write('&lt;script src="https://hb.vntsm.com/v3/live/ad-manager.min.js" type="text/javascript" async&gt;'+'&lt;/scr'+'ipt&gt;');a.document.close()})();
+&lt;/script&gt;
+&lt;!-- / Venatus Market Ad-Manager (gocomics.com) --&gt;
+
+&lt;!-- GPT --&gt;
+&lt;script async="async" src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"&gt;&lt;/script&gt;
+
+&lt;!-- Amazon --&gt;
+&lt;script&gt;
+    !function(a9,a,p,s,t,A,g){if(a[a9])return;function q(c,r){a[a9]._Q.push([c,r])}a[a9]={init:function(){q("i",arguments)},fetchBids:function(){q("f",arguments)},setDisplayBids:function(){},targetingKeys:function(){return[]},_Q:[]};A=p.createElement(s);A.async=!0;A.src=t;g=p.getElementsByTagName(s)[0];g.parentNode.insertBefore(A,g)}("apstag",window,document,"script","////c.amazon-adsystem.com/aax2/apstag.js");
+&lt;/script&gt;
+
+&lt;script&gt;
+    /***** Helper functions for ads *****/
+    var storeQueryString = function(){
+        var queryString = window.location.search.substring(1).split('&amp;');
+        for(var i=0; i&lt;queryString.length; i++){
+            var pair = queryString[i].split('=');
+            if(pair.length === 2){
+                amu_ads.query_string[pair[0]] = pair[1];
+            }
+        }
+    };
+
+    var findAds = function(className) {
+        var ads = document.getElementsByClassName(className);
+        ads = Array.prototype.slice.call(ads);
+        ads.map(function(element) {element.classList.remove(className);});
+
+        return ads
+    };
+
+    var getAdInfo = function (adElements) {
+        var adIds = adElements.map(getElementInfo);
+        adIds = adIds.filter(adSlotConfigExists).filter(servesAtBreakpoint);
+
+        return adIds;
+    };
+
+    var getAdSlot = function (slotInfo) {
+        return amu_ads.adSlots[slotInfo.id];
+    };
+
+    var adSlotConfigExists = function(slotInfo){
+        return typeof amu_ads.adSlotConfig[slotInfo.adType] !== 'undefined';
+    };
+
+    var servesAtBreakpoint = function(slotInfo){
+        var curBpt = amu_ads.adSlotConfig[slotInfo.adType].breakpoint;
+        return curBpt.sizes.length &gt; 0;
+    };
+
+    var getElementId = function(element){
+        return element.id;
+    };
+
+    var getElementAdType = function(element){
+        return element.getAttribute('data-ad-type');
+    };
+
+    var getElementInfo = function(element){
+        return {id: getElementId(element), adType: getElementAdType(element)};
+    };
+
+    var findBreakpoint = function(breakpointsArray){
+        var maxBpt, curBpt;
+        for (var i = 0; i &lt; breakpointsArray.length; i++) {
+            curBpt = breakpointsArray[i];
+            if (amu_ads.browserWidth &gt;= curBpt.minWidth &amp;&amp; amu_ads.browserHeight &gt;= curBpt.minHeight){
+                if(!maxBpt || (curBpt.minWidth &gt;= maxBpt.minWidth &amp;&amp; curBpt.minHeight &gt;= maxBpt.minHeight)){
+                    maxBpt = curBpt;
+                }
+            }
+        }
+        return maxBpt
+    };
+
+
+    var updatePageviewTargeting = function() {
+        var adPageview = getPageviewFromCookie();
+        Object.keys(amu_ads.adSlotConfig).forEach(function(key) {
+            amu_ads.adSlotConfig[key].targeting['pv'] = adPageview;
+        });
+    };
+
+    var adLazyLoaderInit = function (className) {
+        var adElements = Array.prototype.slice.call(document.getElementsByClassName(className));
+
+        adElements.forEach(function(element) {
+            element.classList.remove(className);
+            amu_ads.adLazyLoader.observe(element);
+        });
+    };
+
+    var adRefresherInit = function (className) {
+        if(!isEU){
+            var adElements = Array.prototype.slice.call(document.getElementsByClassName(className));
+
+            adElements.forEach(function(element) {
+                element.classList.remove(className);
+                amu_ads.adRefresher.observe(element);
+            });
+
+            if(typeof(amu_ads.adRefreshInterval) === 'undefined') {
+                amu_ads.adRefreshInterval = window.setInterval(handleAdRefreshInterval, amu_ads.adRefreshRate);
+            }
+        }
+    };
+
+    var handleAdLazyLoad = function (entries, observer) {
+        entries.forEach(function(entry) {
+            if(entry.isIntersecting){
+                // run auction on these elements
+                var adInfo = getAdInfo([entry.target]);
+                auctionInit(adInfo, false);
+                amu_ads.adLazyLoader.unobserve(entry.target);
+            }
+        });
+    };
+
+    var handleAdRefresh = function (entries, observer) {
+        var curAdId, curAdElement;
+        entries.forEach(function(entry) {
+            curAdElement = entry.target;
+            curAdId = curAdElement.id;
+            if(entry.intersectionRatio &gt;= 0.50) {
+                if(amu_ads.adSlots[curAdId]){
+                    amu_ads.inViewAds[curAdId] = curAdElement;
+                }
+            } else {
+                delete amu_ads.inViewAds[curAdId];
+            }
+        });
+    };
+
+    var handleAdRefreshInterval = function () {
+        if(amu_ads.adRefreshCount &lt; amu_ads.adRefreshMax) {
+            if(!document.hidden){
+
+                // Refresh in view ads
+                var adInfo = getAdInfo(Object.values(amu_ads.inViewAds));
+                auctionInit(adInfo, true);
+                // Update refresh count and clear inViewAds
+                amu_ads.adRefreshCount += 1;
+            }
+        } else {
+
+            // Stop refreshing
+            clearInterval(amu_ads.adRefreshInterval)
+        }
+    }
+
+&lt;/script&gt;
+&lt;script&gt;
+    // Global variable for advertising config
+    var amu_ads = amu_ads || {};
+
+    // Query string for changing ad slot path and ad channel
+    amu_ads.query_string = amu_ads.query_string || {};
+
+    // Browser and page info
+    amu_ads.browserWidth = "CSS1Compat" == window.document.compatMode ? window.document.documentElement.clientWidth : window.document.body.clientWidth;
+    amu_ads.browserHeight = "CSS1Compat" == window.document.compatMode ? window.document.documentElement.clientHeight : window.document.body.clientHeight;
+    amu_ads.pageDomain = window.location.hostname;
+    amu_ads.pagePath = window.location.pathname + location.search + location.hash;
+
+    // Ad channel (a or b)
+    amu_ads.adChannel = 'a';
+
+    // Current page view number (based on cookie)
+    amu_ads.adPageview = setPageviewCookie();
+
+    // Ad unit path
+    amu_ads.adSlotPath = '/19196947/gocomics.com/comic/cw';
+
+
+    // Intersection observer for lazy loading ads
+    amu_ads.adLazyLoadOptions = {
+        rootMargin: amu_ads.browserWidth &gt;= 992 ? '300px' : '200px',
+        threshold: 0
+    };
+    amu_ads.adLazyLoader = new IntersectionObserver(handleAdLazyLoad, amu_ads.adLazyLoadOptions);
+
+
+    // Intersection observer for refreshing in view ads
+    amu_ads.adRefreshOptions = {
+        threshold: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+    };
+    amu_ads.adRefresher = new IntersectionObserver(handleAdRefresh, amu_ads.adRefreshOptions);
+    amu_ads.inViewAds = {};
+    amu_ads.adRefreshCount = 0;
+    amu_ads.adRefreshMax = 5;
+    amu_ads.adRefreshRate = 30000;
+
+    // Place to store DFP ad slots (needed in order to refresh ads)
+    amu_ads.adSlots = {};
+
+
+
+    /***** Bidder config *****/
+    // AppNexus tag config
+    amu_ads.appnexusTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337721,
+                keywords: {
+                    pos: ['top'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_1': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337722,
+                keywords: {
+                    pos: ['mid_1'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_2': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337723,
+                keywords: {
+                    pos: ['mid_2'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 320x50
+        'locked': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337724,
+                keywords: {
+                    pos: ['locked'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 728x90
+        'bot': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337725,
+                keywords: {
+                    pos: ['bot'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '1': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337716,
+                keywords: {
+                    pos: ['1'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 300x250
+        '2': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337720,
+                keywords: {
+                    pos: ['2'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'right': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337717,
+                keywords: {
+                    pos: ['right'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'left': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337718,
+                keywords: {
+                    pos: ['left'],
+                    channel: [amu_ads.adChannel]
+                }
+
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'comments': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13337719,
+                keywords: {
+                    pos: ['comments'],
+                    channel: [amu_ads.adChannel]
+                }
+            }
+        }
+    };
+
+    // Index tag config
+    amu_ads.ixTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        '970x250_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '267537',
+                size: [970,250]
+            }
+        },
+        '970x90_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '267537',
+                size: [970,90]
+            }
+        },
+        '728x90_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '267537',
+                size: [728,90]
+            }
+        },
+        '320x50_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '267537',
+                size: [320,50]
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        '970x90_mid_1': {
+            bidder: 'ix',
+            params: {
+                siteId: '267538',
+                size: [970,90]
+            }
+        },
+        '728x90_mid_1': {
+            bidder: 'ix',
+            params: {
+                siteId: '267538',
+                size: [728,90]
+            }
+        },
+        '320x50_mid_1': {
+            bidder: 'ix',
+            params: {
+                siteId: '267538',
+                size: [320,50]
+            }
+        },
+        '300x250_mid_1': {
+            bidder: 'ix',
+            params: {
+                siteId: '267538',
+                size: [300,250]
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        '970x90_mid_2': {
+            bidder: 'ix',
+            params: {
+                siteId: '267539',
+                size: [970,90]
+            }
+        },
+        '728x90_mid_2': {
+            bidder: 'ix',
+            params: {
+                siteId: '267539',
+                size: [728,90]
+            }
+        },
+        '320x50_mid_2': {
+            bidder: 'ix',
+            params: {
+                siteId: '267539',
+                size: [320,50]
+            }
+        },
+        '300x250_mid_2': {
+            bidder: 'ix',
+            params: {
+                siteId: '267539',
+                size: [300,250]
+            }
+        },
+
+        // 320x50
+        '320x50_locked': {
+            bidder: 'ix',
+            params: {
+                siteId: '267540',
+                size: [320,50]
+            }
+        },
+
+        // 728x90
+        '728x90_bot': {
+            bidder: 'ix',
+            params: {
+                siteId: '267541',
+                size: [728,90]
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '300x250_1': {
+            bidder: 'ix',
+            params: {
+                siteId: '267532',
+                size: [300,250]
+            }
+        },
+
+        // 300x250
+        '300x250_2': {
+            bidder: 'ix',
+            params: {
+                siteId: '267536',
+                size: [300,250]
+            }
+        },
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        '300x250_right': {
+            bidder: 'ix',
+            params: {
+                siteId: '267533',
+                size: [300,250]
+            }
+        },
+        '160x600_right': {
+            bidder: 'ix',
+            params: {
+                siteId: '267533',
+                size: [160,600]
+            }
+        },
+        '300x600_right': {
+            bidder: 'ix',
+            params: {
+                siteId: '267533',
+                size: [300,600]
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        '300x250_left': {
+            bidder: 'ix',
+            params: {
+                siteId: '267534',
+                size: [300,250]
+            }
+        },
+        '160x600_left': {
+            bidder: 'ix',
+            params: {
+                siteId: '267534',
+                size: [160,600]
+            }
+        },
+        '300x600_left': {
+            bidder: 'ix',
+            params: {
+                siteId: '267534',
+                size: [300,600]
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        '300x250_comments': {
+            bidder: 'ix',
+            params: {
+                siteId: '267535',
+                size: [300,250]
+            }
+        },
+        '160x600_comments': {
+            bidder: 'ix',
+            params: {
+                siteId: '267535',
+                size: [160,600]
+            }
+        },
+        '300x600_comments': {
+            bidder: 'ix',
+            params: {
+                siteId: '267535',
+                size: [300,600]
+            }
+        }
+    };
+
+    // OpenX tag config
+    amu_ads.openxTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'openx',
+            params: {
+                unit: 540023521,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'top',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_1': {
+            bidder: 'openx',
+            params: {
+                unit: 540023523,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'mid_1',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_2': {
+            bidder: 'openx',
+            params: {
+                unit: 540023535,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'mid_2',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 320x50
+        'locked': {
+            bidder: 'openx',
+            params: {
+                unit: 540023537,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'locked',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 728x90
+        'bot': {
+            bidder: 'openx',
+            params: {
+                unit: 540023544,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'bot',
+                    channel:
+                    amu_ads.adChannel
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '1': {
+            bidder: 'openx',
+            params: {
+                unit: 540023496,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: '1',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 300x250
+        '2': {
+            bidder: 'openx',
+            params: {
+                unit: 540023512,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: '2',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'right': {
+            bidder: 'openx',
+            params: {
+                unit: 540023499,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'right',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'left': {
+            bidder: 'openx',
+            params: {
+                unit: 540023507,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'left',
+                    channel: amu_ads.adChannel
+                }
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'comments': {
+            bidder: 'openx',
+            params: {
+                unit: 540023510,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'comments',
+                    channel: amu_ads.adChannel
+                }
+            }
+        }
+    };
+
+    // PubMatic tag config
+    amu_ads.pubmaticTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090029'
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_1': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090030'
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_2': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090031'
+            }
+        },
+
+        // 320x50
+        'locked': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090032'
+            }
+        },
+
+        // 728x90
+        'bot': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090033'
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '1': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090024'
+            }
+        },
+
+        // 300x250
+        '2': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090028'
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'right': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090025'
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'left': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090026'
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'comments': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '2090027'
+            }
+        }
+    };
+
+    // Rubicon tag config
+    amu_ads.rubiconTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935870,
+                visitor: {
+                    'pos': ['top'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_1': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935874,
+                visitor: {
+                    'pos': ['mid_1'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 970x90, 728x90, 320x50, 300x250
+        'mid_2': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935876,
+                visitor: {
+                    'pos': ['mid_2'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 320x50
+        'locked': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935880,
+                visitor: {
+                    'pos': ['locked'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 728x90
+        'bot': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935884,
+                visitor: {
+                    'pos': ['bot'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '1': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935850,
+                visitor: {
+                    'pos': ['1'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 300x250
+        '2': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935864,
+                visitor: {
+                    'pos': ['2'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'right': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935854,
+                visitor: {
+                    'pos': ['right'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'left': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935878,
+                visitor: {
+                    'pos': ['left'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'comments': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 192270,
+                zoneId: 935860,
+                visitor: {
+                    'pos': ['comments'],
+                    'channel': [amu_ads.adChannel]
+                }
+            }
+        }
+    };
+
+    // Sovrn tag config
+    amu_ads.sovrnTags = {
+        /***** Leaderboards and banners *****/
+        // 970x250, 728x90, 320x50
+        '970x250_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564744'
+            }
+        },
+        '728x90_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564745'
+            }
+        },
+        '320x50_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564746'
+            }
+        },
+
+        // 728x90, 320x50, 300x250
+        '728x90_mid_1': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564747'
+            }
+        },
+        '320x50_mid_1': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564748'
+            }
+        },
+        '300x250_mid_1': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '578781'
+            }
+        },
+
+        // 728x90, 320x50, 300x250
+        '728x90_mid_2': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564749'
+            }
+        },
+        '320x50_mid_2': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564750'
+            }
+        },
+        '300x250_mid_2': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '578782'
+            }
+        },
+
+        // 320x50
+        '320x50_locked': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564751'
+            }
+        },
+
+        // 728x90
+        '728x90_bot': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564752'
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '300x250_1': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564733'
+            }
+        },
+
+        // 300x250
+        '300x250_2': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564743'
+            }
+        },
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        '300x250_right': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564734'
+            }
+        },
+        '160x600_right': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564735'
+            }
+        },
+        '300x600_right': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564736'
+            }
+        },
+
+
+        // 300x250, 160x600, 300x600
+        '300x250_left': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564737'
+            }
+        },
+        '160x600_left': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564738'
+            }
+        },
+        '300x600_left': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564739'
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        '300x250_comments': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564740'
+            }
+        },
+        '160x600_comments': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564741'
+            }
+        },
+        '300x600_comments': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '564742'
+            }
+        }
+
+    };
+
+    // AppNexus tag config
+    amu_ads.tripleliftTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_top_multisize',
+            }
+        },
+
+        // 728x90, 320x50, 300x250
+        'mid_1': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_mid_1_multisize',
+            }
+        },
+
+        // 728x90, 320x50, 300x250
+        'mid_2': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_mid_2_multisize',
+            }
+        },
+
+        // 320x50
+        'locked': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_locked_320x50_hdx',
+            }
+        },
+
+        // 728x90
+        'bot': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_bot_728x90',
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '1': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_rectangle1_300x250',
+            }
+        },
+
+        // 300x250
+        '2': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_rectangle2_300x250',
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'right': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_right_multisize_hdx',
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'left': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_left_multisize_hdx',
+
+            }
+        },
+
+        // 300x250, 160x600, 300x600
+        'comments': {
+            bidder: 'triplelift',
+            params: {
+                inventoryCode: 'gocomics_comments_multisize_hdx',
+            }
+        }
+    };
+
+
+
+    /***** Ad config *****/
+    // TODO: refactor/consolidate ad slot configs when layouts are more consistent
+    amu_ads.adSlotConfig = {};
+    amu_ads.adSlotConfig['leaderboard'] = {
+        name: 'leaderboard',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'top',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 970,
+                minHeight: 850,
+                sizes: [[970, 90], [970, 250], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x250_top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['970x250_top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['320x50_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['leaderboard'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['leaderboard'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['leaderboard_home'] = {
+        name: 'leaderboard_home',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'top',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['320x50_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['leaderboard_home'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['leaderboard_home'].breakpoints);
+
+
+    // When setting leaderboard breakpoints remember to set the shortest size first in the sizes array to avoid screen bounce.
+    amu_ads.adSlotConfig['leaderboard_feature_item'] = {
+        name: 'leaderboard_feature_item',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'top',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1310,
+                minHeight: 850,
+                sizes: [[970, 90], [970, 250], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x250_top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['970x250_top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 1310,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 850,
+                sizes: [[970, 90], [970, 250], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x250_top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['970x250_top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['320x50_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['leaderboard_feature_item'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['leaderboard_feature_item'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['leaderboard_feature_overview'] = {
+        name: 'leaderboard_feature_overview',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'top',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1310,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['320x50_top'],
+                    amu_ads.tripleliftTags['top']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['leaderboard_feature_overview'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['leaderboard_feature_overview'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner1'] = {
+        name: 'banner1',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'mid_1',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['728x90_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['728x90_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1'],
+                    amu_ads.tripleliftTags['mid_1']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['970x90_mid_1'],
+                    amu_ads.ixTags['728x90_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['728x90_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['728x90_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['728x90_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1'],
+                    amu_ads.tripleliftTags['mid_1']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['320x50_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['320x50_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1'],
+                    amu_ads.tripleliftTags['mid_1']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner1'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner1'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner2'] = {
+        name: 'banner2',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'mid_2',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['728x90_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['728x90_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2'],
+                    amu_ads.tripleliftTags['mid_2']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['970x90_mid_2'],
+                    amu_ads.ixTags['728x90_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['728x90_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['728x90_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['728x90_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2'],
+                    amu_ads.tripleliftTags['mid_2']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['320x50_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['320x50_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2'],
+                    amu_ads.tripleliftTags['mid_2']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner2'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner2'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner_explore1'] = {
+        name: 'banner_explore1',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'mid_1',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1145,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['728x90_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['728x90_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1'],
+                    amu_ads.tripleliftTags['mid_1']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_1'],
+                    amu_ads.ixTags['320x50_mid_1'],
+                    amu_ads.ixTags['300x250_mid_1'],
+                    amu_ads.openxTags['mid_1'],
+                    amu_ads.pubmaticTags['mid_1'],
+                    amu_ads.rubiconTags['mid_1'],
+                    amu_ads.sovrnTags['320x50_mid_1'],
+                    amu_ads.sovrnTags['300x250_mid_1'],
+                    amu_ads.tripleliftTags['mid_1']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner_explore1'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner_explore1'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner_explore2'] = {
+        name: 'banner_explore2',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'mid_2',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1145,
+                minHeight: 0,
+                sizes: [[728, 90], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['728x90_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['728x90_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2'],
+                    amu_ads.tripleliftTags['mid_2']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['mid_2'],
+                    amu_ads.ixTags['320x50_mid_2'],
+                    amu_ads.ixTags['300x250_mid_2'],
+                    amu_ads.openxTags['mid_2'],
+                    amu_ads.pubmaticTags['mid_2'],
+                    amu_ads.rubiconTags['mid_2'],
+                    amu_ads.sovrnTags['320x50_mid_2'],
+                    amu_ads.sovrnTags['300x250_mid_2'],
+                    amu_ads.tripleliftTags['mid_2']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner_explore2'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner_explore2'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner_bot'] = {
+        name: 'banner_bot',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'bot',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['bot'],
+                    amu_ads.ixTags['728x90_bot'],
+                    amu_ads.openxTags['bot'],
+                    amu_ads.pubmaticTags['bot'],
+                    amu_ads.rubiconTags['bot'],
+                    amu_ads.sovrnTags['728x90_bot'],
+                    amu_ads.tripleliftTags['bot']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner_bot'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner_bot'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['banner_lock'] = {
+        name: 'banner_lock',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'locked',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 768,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            },
+            {
+                minWidth: 0,
+                minHeight: 300,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['locked'],
+                    amu_ads.ixTags['320x50_locked'],
+                    amu_ads.openxTags['locked'],
+                    amu_ads.pubmaticTags['locked'],
+                    amu_ads.rubiconTags['locked'],
+                    amu_ads.sovrnTags['320x50_locked'],
+                    amu_ads.tripleliftTags['locked']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner_lock'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner_lock'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['rectangle1'] = {
+        name: 'rectangle1',
+        targeting: {
+            'fcode': 'cw',
+            'pos': '1',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['1'],
+                    amu_ads.ixTags['300x250_1'],
+                    amu_ads.openxTags['1'],
+                    amu_ads.pubmaticTags['1'],
+                    amu_ads.rubiconTags['1'],
+                    amu_ads.sovrnTags['300x250_1'],
+                    amu_ads.tripleliftTags['1']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['rectangle1'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['rectangle1'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['rectangle2'] = {
+        name: 'rectangle2',
+        targeting: {
+            'fcode': 'cw',
+            'pos': '2',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['2'],
+                    amu_ads.ixTags['300x250_2'],
+                    amu_ads.openxTags['2'],
+                    amu_ads.pubmaticTags['2'],
+                    amu_ads.rubiconTags['2'],
+                    amu_ads.sovrnTags['300x250_2'],
+                    amu_ads.tripleliftTags['2']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['rectangle2'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['rectangle2'].breakpoints);
+
+
+    amu_ads.adSlotConfig['rectangle_sidebar1'] = {
+        name: 'rectangle_sidebar1',
+        targeting: {
+            'fcode': 'cw',
+            'pos': '1',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['1'],
+                    amu_ads.ixTags['300x250_1'],
+                    amu_ads.openxTags['1'],
+                    amu_ads.pubmaticTags['1'],
+                    amu_ads.rubiconTags['1'],
+                    amu_ads.sovrnTags['300x250_1'],
+                    amu_ads.tripleliftTags['1']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['rectangle_sidebar1'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['rectangle_sidebar1'].breakpoints);
+
+
+    // TODO: rename to tower_comic or something later (Will need to coordinate with ADDKT)
+    amu_ads.adSlotConfig['tower'] = {
+        name: 'tower',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'right',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1200,
+                minHeight: 700,
+                sizes: [[300, 600], [160, 600], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x600_right'],
+                    amu_ads.ixTags['160x600_right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x600_right'],
+                    amu_ads.sovrnTags['160x600_right'],
+                    amu_ads.sovrnTags['300x250_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            },
+            {
+                minWidth: 1200,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x250_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 700,
+                sizes: [[160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['160x600_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['160x600_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tower_comments'] = {
+        name: 'tower_comments',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'comments',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 700,
+                sizes: [[300, 600], [160, 600], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['comments'],
+                    amu_ads.ixTags['300x600_comments'],
+                    amu_ads.ixTags['160x600_comments'],
+                    amu_ads.ixTags['300x250_comments'],
+                    amu_ads.openxTags['comments'],
+                    amu_ads.pubmaticTags['comments'],
+                    amu_ads.rubiconTags['comments'],
+                    amu_ads.sovrnTags['300x600_comments'],
+                    amu_ads.sovrnTags['160x600_comments'],
+                    amu_ads.sovrnTags['300x250_comments'],
+                    amu_ads.tripleliftTags['comments']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['comments'],
+                    amu_ads.ixTags['300x250_comments'],
+                    amu_ads.openxTags['comments'],
+                    amu_ads.pubmaticTags['comments'],
+                    amu_ads.rubiconTags['comments'],
+                    amu_ads.sovrnTags['300x250_comments'],
+                    amu_ads.tripleliftTags['comments']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_comments'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_comments'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tower_spotlight'] = {
+        name: 'tower_spotlight',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'right',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x250_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_spotlight'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_spotlight'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tower_nav'] = {
+        name: 'tower_nav',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'left',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 1200,
+                minHeight: 700,
+                sizes: [[300, 600], [160, 600], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['300x600_left'],
+                    amu_ads.ixTags['160x600_left'],
+                    amu_ads.ixTags['300x250_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['300x600_left'],
+                    amu_ads.sovrnTags['160x600_left'],
+                    amu_ads.sovrnTags['300x250_left'],
+                    amu_ads.tripleliftTags['left']
+                ]
+            },
+            {
+                minWidth: 1200,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['300x250_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['300x250_left'],
+                    amu_ads.tripleliftTags['left']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 700,
+                sizes: [[160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['160x600_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['160x600_left'],
+                    amu_ads.tripleliftTags['left']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_nav'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_nav'].breakpoints);
+
+
+    amu_ads.adSlotConfig['tower_left'] = {
+        name: 'tower_left',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'left',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 700,
+                sizes: [[300, 600], [160, 600], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['300x600_left'],
+                    amu_ads.ixTags['160x600_left'],
+                    amu_ads.ixTags['300x250_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['300x600_left'],
+                    amu_ads.sovrnTags['160x600_left'],
+                    amu_ads.sovrnTags['300x250_left'],
+                    amu_ads.tripleliftTags['left']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['300x250_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['300x250_left'],
+                    amu_ads.tripleliftTags['left']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_left'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_left'].breakpoints);
+
+
+
+    // TODO: rename to tower or something later (will need to coordinate with ADDKT)
+    amu_ads.adSlotConfig['tower_explore'] = {
+        name: 'tower_explore',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'right',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 700,
+                sizes: [[300, 600], [160, 600], [300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x600_right'],
+                    amu_ads.ixTags['160x600_right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x600_right'],
+                    amu_ads.sovrnTags['160x600_right'],
+                    amu_ads.sovrnTags['300x250_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            },
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x250_right'],
+                    amu_ads.tripleliftTags['right']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_explore'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_explore'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['sharethrough_home1'] = {
+        name: 'sharethrough_home1',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'sharethrough1',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel,
+            'strnativekey': 'ToUYV7H9xW7PLXQmvtACxrh1'
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[1, 1]],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['sharethrough_home1'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['sharethrough_home1'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['sharethrough_home2'] = {
+        name: 'sharethrough_home2',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'sharethrough2',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel,
+            'strnativekey': 'ToUYV7H9xW7PLXQmvtACxrh1'
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[1, 1]],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['sharethrough_home2'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['sharethrough_home2'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tynt'] = {
+        name: 'tynt',
+        targeting: {
+            'fcode': 'cw',
+            'pos': 'tynt',
+            'pv': amu_ads.adPageview,
+            'channel': amu_ads.adChannel
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[1, 1]],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tynt'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tynt'].breakpoints);
+&lt;/script&gt;
+
+&lt;script&gt;
+    // Venatus
+    var isEU = false;
+    window.VM_API = window.VM_API || [];
+
+    var PREBID_TIMEOUT = 1500;
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+    var customPriceBuckets = {
+        'buckets': [
+            // 1 cent increments up to 50 cents
+            {
+                'min': 0.00,
+                'max': 0.50,
+                'increment': 0.01
+            },
+            // 5 cent increments up to 5 dollars
+            {
+                'min': 0.50,
+                'max': 5.00,
+                'increment': 0.05
+            },
+            // 10 cent increments up to 10 dollars
+            {
+                'min': 5.00,
+                'max': 10.00,
+                'increment': 0.10
+            },
+            // 50 cent increments up to 20 dollars
+            {
+                'min': 10.00,
+                'max': 20.00,
+                'increment': 0.50
+            },
+            // 1 dollar increments up to 50 dollars
+            {
+                'min': 20.00,
+                'max': 50.00,
+                'increment': 1.00
+            }
+        ]
+    };
+
+    pbjs.que.push(function() {
+        pbjs.setConfig({
+            enableSendAllBids: true,
+            priceGranularity: customPriceBuckets,
+            userSync: {
+                iframeEnabled: true
+            }
+        });
+    });
+
+
+    // Confiant
+    // Wrapper for AMUniversal (GoComics), generated on 2018-10-26T16:40:06-04:00, version 2018.04.02
+    pbjs.que.push(function() {
+        // keep a reference to original renderAd function
+        var w = window;
+        w._clrm = w._clrm || {};
+        w._clrm.renderAd = w._clrm.renderAd || pbjs.renderAd;
+        var config = w._clrm.prebid || {
+            /* Enables sandboxing on a device group
+                 All:1 , Desktop:2, Mobile: 3, iOS: 4, Android: 5, Off: 0
+             */
+            sandbox: 0
+        };
+
+        var isGoogleFrame = function (c) {
+            return c.tagName === 'IFRAME' &amp;&amp; c.id &amp;&amp; c.id.indexOf('google_ads_iframe_') &gt; -1;
+        };
+
+        var shouldSandbox = function () {
+            var uaToRegexMap = {
+                    "mobile": /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/i,
+                    "ios": /(.+)(iPhone|iPad|iPod)(.+)OS[\s|\_](\d)\_?(\d)?[\_]?(\d)?.+/i,
+                    "android": /Android/i
+                },
+                sbStr = "" +config.sandbox;
+            if (sbStr === "1") {
+                // all environments
+                return true;
+            } else if (sbStr === "2") {
+                // desktop
+                return !navigator.userAgent.match(uaToRegexMap["mobile"]);
+            } else if (sbStr === "3") {
+                // mobile
+                return navigator.userAgent.match(uaToRegexMap["mobile"]);
+            } else if (sbStr === "4") {
+                // ios only
+                return navigator.userAgent.match(uaToRegexMap["ios"]);
+            } else if (sbStr === "5") {
+                // android
+                return navigator.userAgent.match(uaToRegexMap["android"]);
+            } else {
+                return false;
+            }
+        };
+
+        Node.prototype.appendChild = (function (original) {
+            return function (child) {
+                if (isGoogleFrame(child) &amp;&amp; shouldSandbox() &amp;&amp; !child.getAttribute('sandbox')) {
+                    child.setAttribute('sandbox', 'allow-forms allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation');
+                    child.setAttribute('data-forced-sandbox', true);
+                }
+                return original.call(this, child);
+            };
+        }(Node.prototype.appendChild));
+
+
+        // override renderAd
+        pbjs.renderAd = function(doc, id) {
+            if (doc &amp;&amp; id) {
+                try {
+
+                    // get pbjs bids
+                    var bids = [],
+                        bidResponses = pbjs.getBidResponses(),
+                        highestBids = pbjs.getHighestCpmBids();
+                    for (var slot in bidResponses) {
+                        bids = bids.concat(bidResponses[slot].bids);
+                    }
+                    bids = bids.concat(highestBids);
+
+                    // lookup ad by ad Id (avoid ES6 array functions)
+                    var bid, i;
+                    for (i=0; i&lt;bids.length; i++) {
+                        if (bids[i].adId === id) {
+                            bid = bids[i];
+                            break;
+                        }
+                    }
+
+                    // Optional: list of bidders that don't need wrapping, array of strings, e.g.: ["bidder1", "bidder2"]
+                    var confiantExcludeBidders = [];
+
+                    // check bidder exclusion (avoid ES6 array functions)
+                    var excludeBidder = false;
+                    for (i = 0; i &lt; confiantExcludeBidders.length; i++) {
+                        if (bid.bidder === confiantExcludeBidders[i]) {
+                            excludeBidder = true;
+                            break;
+                        }
+                    }
+
+                    if (bid &amp;&amp; bid.ad &amp;&amp; !excludeBidder) {
+                        // Neutralize document
+                        var docwrite = doc.write;
+                        var docclose = doc.close;
+                        doc.write = doc.close = function() {};
+                        // call renderAd with our neutralized doc.write
+                        window._clrm.renderAd(doc, id);
+                        // Restore document
+                        delete doc.write;
+                        delete doc.close;
+
+                        var callback = function(blockingType, blockingId, isBlocked, wrapperId, tagId, impressionData) {
+                            console.log("w00t one more bad ad nixed.", arguments);
+                        };
+
+                        return;
+                    }
+                } catch (e) {
+                    console.log(e);
+                }
+            }
+
+            // if bid.ad is not defined or if any error occurs, call renderAd to serve the creative
+            window._clrm.renderAd(doc, id);
+        };
+
+    });
+
+
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    googletag.cmd.push(function() {
+        googletag.pubads().disableInitialLoad();
+
+        // Event listener for when slot renders
+        googletag.pubads().addEventListener('slotRenderEnded', function(event) {
+            // Element Id of the slot
+            var slotId = event.slot.getSlotElementId();
+
+            // Update lock targets that load after initial page load
+            if(slotId === "tower_comments") {
+                gcLock.init('[data-gc-lock-depends="tower_comments"]');
+            } else if(slotId === "banner_lock") {
+                if(!event.isEmpty) {
+                    document.querySelector('.js-ad-banner-lock-wrapper').classList.remove('ad-hidden');
+                }
+            }
+        });
+    });
+
+    apstag.init({
+        pubID: 'af9aec0d-17e4-4619-825c-371fa3483a58',
+        adServer: 'googletag'
+    });
+&lt;/script&gt;
+
+&lt;script&gt;
+    function startAuction(bidTimeout, adInfo, adSlots, refresh) {
+        // Define bidders
+        var bidders = ['a9', 'prebid'];
+
+        // create a requestManager to keep track of bidder state to determine when to send ad server
+        // request and what apstagSlots to request from the ad server
+        var requestManager = {
+            adServerRequestSent: false
+        };
+        // add the bidders to the request manager:
+        bidders.forEach(function(bidder) {
+            requestManager[bidder] = false;
+        });
+
+        // return true if all bidders have returned
+        function allBiddersDone () {
+            return bidders.filter(function(bidder) {return requestManager[bidder];}).length === bidders.length;
+        }
+
+        // handler for header bidder responses
+        function bidderDone(bidder) {
+            if (requestManager.adServerRequestSent === false) {
+                // flip the boolean associated with the bidder in the request manager
+                requestManager[bidder] = true;
+
+                // if all bidders are back, send the request to the ad server
+                if (allBiddersDone()) {
+                    sendAdserverRequest(adInfo, adSlots, refresh);
+                }
+            }
+        }
+
+        // actually get ads from DFP
+        function sendAdserverRequest(adInfo, adSlots, refresh) {
+            if (requestManager.adServerRequestSent === false) {
+                requestManager.adServerRequestSent = true;
+                pbjs.que.push(function() {
+                    googletag.cmd.push(function() {
+                        if(!refresh){
+                            // 5. Display Ads
+                            displayAds(adInfo);
+                        }
+
+                        // 6. Refresh bids
+                        refreshAds(adSlots);
+                    });
+                });
+            }
+        }
+
+        function requestBids(adInfo, adSlots) {
+            // Fetch Amazon bids
+            amzn_fetchBids(adInfo, adSlots);
+
+            // Fetch Prebid bids
+            prebid_fetchBids(adInfo, adSlots);
+
+        }
+
+        /***** Amazon helper functions *****/
+        function amzn_buildSlotsArray(adInfo) {
+            var slotsArray = [];
+            var i, curAdId, curAdType;
+            for (i = 0; i &lt; adInfo.length; i++) {
+                curAdId = adInfo[i].id;
+                curAdType = adInfo[i].adType;
+                slotsArray.push({
+                    slotID: curAdId,
+                    sizes: amu_ads.adSlotConfig[curAdType].breakpoint.sizes
+                });
+            }
+            return slotsArray;
+
+        }
+
+        function amzn_fetchBids(adInfo, adSlots) {
+            // Fetch Amazon bids for slots on page
+            apstag.fetchBids(
+                {
+                    slots: amzn_buildSlotsArray(adInfo),
+                    timeout: 1000
+                },
+                function (bids) {
+                    pbjs.que.push(function () {
+                        googletag.cmd.push(function () {
+                            // Set Amazon bid key-values pairs
+                            try {
+                                apstag.setDisplayBids();
+                            } catch (e) {
+                                //do nothing
+                            }
+                        });
+                        bidderDone('a9', adInfo, adSlots);
+                    });
+                }
+            );
+        }
+
+        /* Prebid helper functions */
+        var prebid_fetchBids = function(adInfo, adSlots) {
+            var curAdIds = adInfo.map(function(e){return e.id;});
+            pbjs.que.push(function() {
+                pbjs.requestBids({
+                    timeout: PREBID_TIMEOUT,
+                    adUnitCodes: curAdIds,
+                    bidsBackHandler: function() {
+                        googletag.cmd.push(function() {
+                            pbjs.setTargetingForGPTAsync(curAdIds);
+                        });
+                        bidderDone('prebid', adInfo, adSlots);
+                    }
+                });
+            });
+        };
+
+        // ask bidders for their bids
+        requestBids(adInfo, adSlots);
+        // set timeout to send request to call sendAdserverRequest() after timeout
+        // it all bidders haven't returned before then
+        window.setTimeout(function() {
+            sendAdserverRequest(adInfo, adSlots);
+        }, bidTimeout);
+    }
+&lt;/script&gt;
+
+&lt;script&gt;
+    var buildAdUnits = function(adInfo) {
+        var adUnits = [];
+        var curUnit, curAdId, curAdType;
+        for(var i = 0; i &lt; adInfo.length; i++) {
+            curAdId = adInfo[i].id;
+            curAdType = adInfo[i].adType;
+            curUnit = {
+                code: curAdId,
+                mediaTypes: {
+                    banner: {
+                        sizes: amu_ads.adSlotConfig[curAdType].breakpoint.sizes
+                    }
+                },
+                bids: amu_ads.adSlotConfig[curAdType].breakpoint.bids
+            };
+            adUnits.push(curUnit);
+        }
+        return adUnits
+    };
+
+    var defineAds = function(adInfo) {
+        var slots = [];
+        var i, curSlot, curAdId, curAdType;
+        for (i = 0; i &lt; adInfo.length; i++) {
+            curAdId = adInfo[i].id;
+            curAdType = adInfo[i].adType;
+            // Define slot
+            curSlot = googletag.defineSlot(amu_ads.adSlotPath, amu_ads.adSlotConfig[curAdType].breakpoint.sizes, curAdId).addService(googletag.pubads());
+
+            // Set slot level targeting
+            for (key in amu_ads.adSlotConfig[curAdType].targeting) {
+                curSlot.setTargeting(key, amu_ads.adSlotConfig[curAdType].targeting[key]);
+            }
+
+            slots.push(curSlot);
+
+            // Store slot for later use (refreshing ads, etc)
+            amu_ads.adSlots[curAdId] = curSlot;
+
+        }
+        return slots;
+    };
+
+    var displayAds = function(adInfo) {
+        var curAdId;
+        if(adInfo.length === 0) {
+            googletag.display();
+        } else {
+            for(var i = 0; i &lt; adInfo.length; i++) {
+                curAdId = adInfo[i].id;
+                googletag.display(curAdId);
+            }
+        }
+    };
+
+    var refreshAds = function(adSlots) {
+        for(var i = 0; i &lt; adSlots.length; i++) {
+            adSlots[i].setTargeting('pv', getPageviewFromCookie());
+        }
+
+        if(adSlots.length === 0) {
+            googletag.pubads().refresh();
+        } else {
+            googletag.pubads().refresh(adSlots);
+        }
+    };
+
+    var auctionInit = function(adInfo, refresh) {
+        if(adInfo.length &gt; 0){
+            if(isEU) {
+                googletag.cmd.push(function() {
+                    // Define ads
+                    var adSlots = defineAds(adInfo);
+
+                    // Enable services for GPT
+                    googletag.enableServices();
+
+                    // Display Ads
+                    displayAds(adInfo);
+
+                    // Refresh bids
+                    refreshAds(adSlots);
+                });
+            } else {
+                pbjs.que.push(function() {
+                    googletag.cmd.push(function() {
+                        if(!refresh) {
+                            // Build ad units and add them to Prebid
+                            var adUnits = buildAdUnits(adInfo);
+                            pbjs.addAdUnits(adUnits);
+
+                            // Define ads
+                            var adSlots = defineAds(adInfo);
+
+                            // Enable services for GPT
+                            googletag.enableServices();
+                        } else {
+                            // Get existing ad slots
+                            var adSlots = adInfo.map(getAdSlot);
+                        }
+                        // Start header-bidding auction
+                        startAuction(1500, adInfo, adSlots, refresh);
+                    });
+                });
+            }
+        }
+    };
+
+    // Venatus
+    window.VM_API.push({
+        call: "is-consent-required",
+        onResult: function(res) {
+            //res = true in EU
+            //res = false outside EU
+            isEU = res;
+            if (document.readyState === "loading") {
+                document.addEventListener("DOMContentLoaded", function(event) {
+                    // Find ads
+                    var adElements = findAds('js-ad');
+
+                    // Get ad info
+                    var adInfo = getAdInfo(adElements);
+                    auctionInit(adInfo, false);
+
+                    //Lazy load ads
+                    adLazyLoaderInit('js-ad-lazy-load');
+
+                    // Refresh in view ads
+                    adRefresherInit('js-ad-refresh');
+                });
+            } else {
+                // Find ads
+                var adElements = findAds('js-ad');
+
+                // Get ad info
+                var adInfo = getAdInfo(adElements);
+
+                auctionInit(adInfo, false);
+
+                //Lazy load ads
+                adLazyLoaderInit('js-ad-lazy-load');
+
+                // Refresh ads in view
+                adRefresherInit('js-ad-refresh');
+            }
+        }
+    });
+
+&lt;/script&gt;
+
+
+&lt;!-- Sharethrough --&gt;
+&lt;script type="text/javascript" src="https://native.sharethrough.com/assets/sfp.js"&gt;&lt;/script&gt;
+
+    &lt;!-- Begin Monetate ExpressTag Sync v8.1. Place at start of document head. DO NOT ALTER. --&gt;
+&lt;script type="text/javascript"&gt;var monetateT = new Date().getTime();&lt;/script&gt;
+&lt;script type="text/javascript" src="//se.monetate.net/js/2/a-8760e223/p/gocomics.com/entry.js"&gt;&lt;/script&gt;
+&lt;!-- End Monetate tag --&gt;
+
+&lt;script type="text/javascript"&gt;
+    window.monetateQ = window.monetateQ || [];
+
+    // Set page type
+        window.monetateQ.push([
+        'setPageType',
+        'feature-item'
+    ]);
+
+    // Set custom variables
+    monetateQ.push([
+        'setCustomVariables',
+        [
+            // Feature variables
+            {
+                name: 'featureCode',
+                value: 'cw'
+            },
+
+            // Ad variables
+            {
+                name: 'advertisingChannel',
+                value: 'a'
+            },
+
+            // User variables
+        ]
+    ]);
+
+    // Call trackData when data is ready to be sent to Monetate.
+    // Each time trackData is called, monetateQ is cleared.
+    window.monetateQ.push([
+        "trackData"
+    ]);
+&lt;/script&gt;
+
+    &lt;!-- BEGIN GTM Core Data Layer --&gt;
+&lt;script&gt;
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+        'event': 'dataLayer-loaded',
+        'language': 'english',
+
+        'pageType': 'feature-item',
+
+
+
+        'featureName': '9 chickweed lane',
+        'featureCode': 'cw',
+        'featureType': 'comic',
+        'featureFormat': 'print',
+
+        'featureItemPublishDate': '2019-07-16',
+
+
+        'advertisingChannel': 'a',
+
+        // User variables
+
+        'visitType': 'new',
+
+        'loginStatus': 'logged out'
+    });
+&lt;/script&gt;
+&lt;!-- END GTM Core Data Layer --&gt;
+
+    &lt;!-- Google Tag Manager HEAD? --&gt;
+&lt;script&gt;(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&amp;l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-PN7JV4B');&lt;/script&gt;
+&lt;!-- End Google Tag Manager --&gt;
+
+    &lt;script type="text/javascript"&gt;
+//Set markup and styling here
+window.cookieconsent_options = {
+  container: '#cookieconsent-container',
+  learnMore: 'More info',
+  link: "//www.andrewsmcmeel.com/privacy-policy",
+  //If you wish to use your own CSS instead, specify the URL of your CSS file. e.g. styles/my_custom_theme.css.
+  //This can be a relative or absolute URL.
+  //To stop Cookie Consent from loading CSS at all, specify false
+  //IE8 Styles need to be duplicated in app specific css overrides /assets/stylesheets/ie/ie8.css
+  theme: false,
+  markup: [
+    '&lt;div&gt;',
+    '&lt;style type="text/css"&gt;.cc_banner-wrapper {height: 70px; } .cc_container {position:absolute; width:100%; left:0; top:80px; right:0; overflow:hidden; background-color:#666; } .cookie-choices-info {margin:0; padding:0; text-align:center; color:#fff; line-height:140%; padding:15px 0; font-family:roboto,Arial } .cookie-choices-info .cookie-choices-text {display:inline-block; vertical-align:middle; font-size:16px; margin:10px; color:#fefefe; max-width:800px; text-align:center } .cookie-choices-info .cookie-choices-buttons {display:inline-block; vertical-align:middle; white-space:nowrap; margin:10px } .cookie-choices-info .cookie-choices-button:hover {color:#fff; background-color:#000 } .cookie-choices-info .cookie-choices-button {background:#444; font-weight:700; text-transform:UPPERCASE; white-space:nowrap; color:#eee; margin-left:8px; padding:10px; border-radius:3px; text-decoration:none } @media screen and (max-width: 992px) {.cc_container {top: 60px}} @media screen and (max-width: 851px) {.cc_container {top: 60px} .cc_banner-wrapper {height:110px } } @media screen and (max-width: 588px) {.cc_banner-wrapper {height:140px} } @media screen and (max-width: 327px) {.cc_banner-wrapper {height:160px} } @media print {.cc_banner-wrapper,.cc_container {display:none } }&lt;/style&gt;',
+    '&lt;div class="cc_banner-wrapper {{containerClasses}}"&gt;',
+    '&lt;div class="cc_banner cc_container cc_container--open"&gt;',
+    '&lt;div class="cookie-choices-info"&gt;&lt;div class="cookie-choices-inner"&gt;&lt;span class="cookie-choices-text"&gt;{{options.message}}&lt;/span&gt;&lt;span class="cookie-choices-buttons"&gt; &lt;a data-cc-if="options.link" class="cookie-choices-button" target="_blank" href="{{options.link || "#null"}}"&gt;{{options.learnMore}}&lt;/a&gt; &lt;a id="cookieChoiceDismiss" href="#null" data-cc-event="click:dismiss"  class="cookie-choices-button"&gt;{{options.dismiss}}&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;&lt;/div&gt;',
+    '&lt;/div&gt;',
+    '&lt;/div&gt;',
+    '&lt;/div&gt;'
+  ],
+  cookieName: 'gocomics_cookieconsent_dismissed',
+  readystate: 'interactive'
+};
+&lt;/script&gt;
+
+    &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.2.0/css/font-awesome.css" integrity="sha384-acGNjq0ZO3YC8YdbDezfdh+P9JYzpbVLNKWULhNFraiKnRIhnbcb75B7Jvzqf3hA" crossorigin="anonymous"&gt;
+  &lt;/head&gt;
+  &lt;body role="document" data-controller="feature_items" data-action="feature-lander" class="js-gc-page-item gc-page-item gc-profile-casual 9chickweedlane"&gt;
+
+    &lt;!-- All Server-Side Analytic Values or Markup (No Script Calls or Heavy Client-Side Scripting) --&gt;
+
+&lt;!-- Google Tag Manager (noscript) --&gt;
+&lt;noscript&gt;&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PN7JV4B" height="0" width="0" style="display:none;visibility:hidden"&gt;&lt;/iframe&gt;&lt;/noscript&gt;
+&lt;!-- End Google Tag Manager (noscript) --&gt;
+
+
+
+
+
+
+
+
+
+
+
+
+
+&lt;!-- TEST:  --&gt;
+
+
+
+
+&lt;script type="text/javascript"&gt;
+    amuGc.env = "production";
+    amuGc.displayAds = true;
+    amuGc.uaCategoryGroup = 'comic strips';
+    amuGc.uaSubcategoryGroup = '';
+    amuGc.uaTypeGroup = 'print';
+    amuGc.uaClientName = "gocomics";
+    amuGc.uaFeatureName = '9 chickweed lane';
+    amuGc.uaUserType = 'casual';
+    amuGc.uaUserId = '';
+    amuGc.uaUserPromo = '';
+    amuGc.qcLabel = 'comic.9chickweedlane'
+&lt;/script&gt;
+&lt;!-- Google Universal Analytics End --&gt;
+
+    &lt;div class="js-amu-container-global"&gt;
+      &lt;!-- Start Site Header --&gt;
+&lt;div class="gc-site-header js-navbar"&gt;
+  &lt;header class="gc-content__1col gc-gap-none"&gt;
+
+    &lt;nav class='navbar navbar-expand-lg navbar-light bg-white gc-nav-primary container'&gt;
+
+      &lt;button class='navbar-toggler collapsed gc-hamburger' type='button' data-toggle='collapse' data-target='.gc-nav-primary__left-menu' aria-controls='gc-nav-primary__left-menu' aria-expanded='false' aria-label='Toggle navigation'&gt;
+
+        &lt;div class='gc-hamburger__icon'&gt;
+          &lt;span&gt;&lt;/span&gt;
+          &lt;span&gt;&lt;/span&gt;
+          &lt;span&gt;&lt;/span&gt;
+        &lt;/div&gt;
+
+      &lt;/button&gt;
+
+      &lt;a title="GoComics Home" class="navbar-brand gc-logo" data-link-type="header-nav-tier-1" href="https://www.gocomics.com/"&gt;
+        &lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  --&gt;
+&lt;svg version="1.1" class="gc-logo__default" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewbox="161 314.5 934.6 165.5" style="enable-background:new 161 314.5 934.6 165.5;" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"&gt;
+	&lt;path d="M437.5,456.8h-23.6v-7.2c-6.3,5.1-16.6,9.3-30.5,9.3c-37.2,0-62.8-25.4-62.8-63.3c0-34.7,25-63.1,62.8-63.1
+		c25.7,0,41.6,11.1,50.1,24.2l-19,14.1c-5.6-7.6-14.8-15.5-31-15.5c-22,0-37.2,16.6-37.2,40.4c0,24.7,16.2,40.7,38.3,40.7
+		c14.1,0,24-5.5,29.1-10.8v-13.9h-19.9v-20.5h43.9v65.6H437.5z"&gt;&lt;/path&gt;
+	&lt;path class="g-path" d="M497,360.9c29.8,0,49.4,20.8,49.4,48.7c0,27.7-20.3,48.8-49.4,48.8c-29.4,0-49.2-20.6-49.2-48.5
+		C447.8,381.9,468.7,360.9,497,360.9z M497.2,437.1c15.5,0,25.6-11.6,25.6-27.3c0-15.7-10.6-27.5-25.8-27.5
+		c-15.5,0-25.6,11.6-25.6,27.5C471.5,425.6,482.1,437.1,497.2,437.1z"&gt;&lt;/path&gt;
+	&lt;path class="o-path" d="M659.8,443.1c-9.3,9.2-22.7,16-40.4,16c-39.3,0-64-27.2-64-63.1c0-35.8,25.4-63.5,63.5-63.5c17.5,0,30.9,5.6,40.6,14.3
+		L645,365.2c-5.6-4.9-14.6-9.9-25.9-9.9c-23.6,0-37.9,17.6-37.9,40.6c0,23.1,15.3,40.4,38.3,40.4c12.3,0,21-5.8,26.1-10.2
+		L659.8,443.1z"&gt;&lt;/path&gt;
+	&lt;path class="c-path" d="M708,360.9c29.8,0,49.4,20.8,49.4,48.7c0,27.7-20.3,48.8-49.4,48.8c-29.4,0-49.2-20.6-49.2-48.5
+		C658.8,381.9,679.6,360.9,708,360.9z M708.2,437.1c15.5,0,25.6-11.6,25.6-27.3c0-15.7-10.6-27.5-25.8-27.5
+		c-15.5,0-25.6,11.6-25.6,27.5C682.4,425.6,693,437.1,708.2,437.1z"&gt;&lt;/path&gt;
+	&lt;path class="o-path" d="M839.9,456.8h-23.6v-59.4c0-9-4.2-15-12.5-15c-8.5,0-12.9,6-12.9,15.3v59.1h-23.6v-94.3h23.6v7.1c2.5-3,8.3-8.1,20.3-8.1
+		c11.1,0,18.2,4.2,22.4,10.2c4.2-4.9,11.3-10.2,23.6-10.2c23.3,0,31.7,15,31.7,33.1v62.2h-23.6v-59.4c0-9.2-4.2-15-12.7-15
+		s-12.7,6.5-12.7,15V456.8z"&gt;&lt;/path&gt;
+	&lt;path class="m-path" d="M902.8,342.6c0-7.9,6.3-14.3,14.1-14.3c7.9,0,14.1,6.3,14.1,14.3c0,7.8-6.2,13.9-14.1,13.9
+		C909.2,356.5,902.8,350.3,902.8,342.6z M928.8,456.8h-23.6v-94.3h23.6V456.8z"&gt;&lt;/path&gt;
+	&lt;path class="i-path" d="M1009.3,429.3l13,15.9c-5.6,6-16.8,13.2-33,13.2c-29.8,0-48.8-21.2-48.8-48.5c0-27.5,20.5-49,48.7-49
+		c17.1,0,27.5,6.9,33.2,12.7l-13.6,16.4c-3.9-3.7-10.1-7.8-19.4-7.8c-15.5,0-25.2,11.8-25.2,27.5c0,16.9,11.8,27.3,25.4,27.3
+		C999.1,437.1,1005.1,432.9,1009.3,429.3z"&gt;&lt;/path&gt;
+	&lt;path class="c2-path" d="M1060.1,396.4c4.2,1.2,8.1,1.9,12.9,3.4c15.2,4.6,22.6,12,22.6,29.1c0,19.2-15.9,29.3-34.4,29.3
+		c-26.1,0-34.2-15.3-33.7-31.7h22.6c0,6.7,2.3,12.7,11.5,12.7c6.2,0,11.1-3,11.1-8.5s-2.8-7.9-9.3-9.7c-5.1-1.4-9.2-2.3-14.3-4.2
+		c-13-4.8-19.6-13.6-19.6-27.9c0-15.9,13.4-27.5,32.3-27.5c19.9,0,31.7,10.1,31.9,29.8H1072c-0.2-7.2-3.5-11.5-10.8-11.5
+		c-5.6,0-9.3,3.2-9.3,7.9C1051.8,392.1,1054.5,394.8,1060.1,396.4z"&gt;&lt;/path&gt;
+	&lt;path class="s-path" d="M161,314.5v95c0,43.5,26.5,70.5,69.1,70.5c41.5,0,69.5-28.4,69.5-70.7v-94.8H161z M244.2,351c5.6,0,10.1,4.5,10.1,10.1
+		s-4.5,10.1-10.1,10.1s-10.1-4.5-10.1-10.1C234.2,355.5,238.7,351,244.2,351z M213.9,352.9c4.5,0,8.1,3.6,8.1,8.1s-3.6,8.1-8.1,8.1
+		s-8.1-3.6-8.1-8.1C205.8,356.6,209.4,352.9,213.9,352.9z M278.9,409.3c0,28.9-16.9,50.1-48.8,50.1c-33.1,0-48.5-19.9-48.5-49.9
+		v-57.2h11.1v57.2c0,12.6,3,22.2,8.9,28.7c6.1,6.7,15.7,10.1,28.5,10.1c24,0,37.8-14.2,37.8-39v-74.2H279v74.2H278.9z"&gt;&lt;/path&gt;
+&lt;/svg&gt;
+
+        &lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  --&gt;
+&lt;svg version="1.1" class="gc-logo__wink" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewbox="161 314.5 934.6 165.5" style="enable-background:new 161 314.5 934.6 165.5;" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"&gt;
+	&lt;path class="face-path" d="M437.5,456.8h-23.6v-7.2c-6.3,5.1-16.6,9.3-30.5,9.3c-37.2,0-62.8-25.4-62.8-63.3c0-34.7,25-63.1,62.8-63.1
+		c25.7,0,41.6,11.1,50.1,24.2l-19,14.1c-5.6-7.6-14.8-15.5-31-15.5c-22,0-37.2,16.6-37.2,40.4c0,24.7,16.2,40.7,38.3,40.7
+		c14.1,0,24-5.5,29.1-10.8v-13.9h-19.9v-20.5h43.9v65.6H437.5z"&gt;&lt;/path&gt;
+	&lt;path class="g-path" d="M497,360.9c29.8,0,49.4,20.8,49.4,48.7c0,27.7-20.3,48.8-49.4,48.8c-29.4,0-49.2-20.6-49.2-48.5
+		C447.8,381.9,468.7,360.9,497,360.9z M497.2,437.1c15.5,0,25.6-11.6,25.6-27.3c0-15.7-10.6-27.5-25.8-27.5
+		c-15.5,0-25.6,11.6-25.6,27.5C471.5,425.6,482.1,437.1,497.2,437.1z"&gt;&lt;/path&gt;
+	&lt;path class="o-path" d="M659.8,443.1c-9.3,9.2-22.7,16-40.4,16c-39.3,0-64-27.2-64-63.1c0-35.8,25.4-63.5,63.5-63.5c17.5,0,30.9,5.6,40.6,14.3
+		L645,365.2c-5.6-4.9-14.6-9.9-25.9-9.9c-23.6,0-37.9,17.6-37.9,40.6c0,23.1,15.3,40.4,38.3,40.4c12.3,0,21-5.8,26.1-10.2
+		L659.8,443.1z"&gt;&lt;/path&gt;
+	&lt;path class="c-path" d="M708,360.9c29.8,0,49.4,20.8,49.4,48.7c0,27.7-20.3,48.8-49.4,48.8c-29.4,0-49.2-20.6-49.2-48.5
+		C658.8,381.9,679.6,360.9,708,360.9z M708.2,437.1c15.5,0,25.6-11.6,25.6-27.3c0-15.7-10.6-27.5-25.8-27.5
+		c-15.5,0-25.6,11.6-25.6,27.5C682.4,425.6,693,437.1,708.2,437.1z"&gt;&lt;/path&gt;
+	&lt;path class="o2-path" d="M839.9,456.8h-23.6v-59.4c0-9-4.2-15-12.5-15c-8.5,0-12.9,6-12.9,15.3v59.1h-23.6v-94.3h23.6v7.1c2.5-3,8.3-8.1,20.3-8.1
+		c11.1,0,18.2,4.2,22.4,10.2c4.2-4.9,11.3-10.2,23.6-10.2c23.3,0,31.7,15,31.7,33.1v62.2h-23.6v-59.4c0-9.2-4.2-15-12.7-15
+		s-12.7,6.5-12.7,15V456.8z"&gt;&lt;/path&gt;
+	&lt;path class="m-path" d="M902.8,342.6c0-7.9,6.3-14.3,14.1-14.3c7.9,0,14.1,6.3,14.1,14.3c0,7.8-6.2,13.9-14.1,13.9
+		C909.2,356.5,902.8,350.3,902.8,342.6z M928.8,456.8h-23.6v-94.3h23.6V456.8z"&gt;&lt;/path&gt;
+	&lt;path class="i-path" d="M1009.3,429.3l13,15.9c-5.6,6-16.8,13.2-33,13.2c-29.8,0-48.8-21.2-48.8-48.5c0-27.5,20.5-49,48.7-49
+		c17.1,0,27.5,6.9,33.2,12.7l-13.6,16.4c-3.9-3.7-10.1-7.8-19.4-7.8c-15.5,0-25.2,11.8-25.2,27.5c0,16.9,11.8,27.3,25.4,27.3
+		C999.1,437.1,1005.1,432.9,1009.3,429.3z"&gt;&lt;/path&gt;
+	&lt;path class="c-path" d="M1060.1,396.4c4.2,1.2,8.1,1.9,12.9,3.4c15.2,4.6,22.6,12,22.6,29.1c0,19.2-15.9,29.3-34.4,29.3
+		c-26.1,0-34.2-15.3-33.7-31.7h22.6c0,6.7,2.3,12.7,11.5,12.7c6.2,0,11.1-3,11.1-8.5s-2.8-7.9-9.3-9.7c-5.1-1.4-9.2-2.3-14.3-4.2
+		c-13-4.8-19.6-13.6-19.6-27.9c0-15.9,13.4-27.5,32.3-27.5c19.9,0,31.7,10.1,31.9,29.8H1072c-0.2-7.2-3.5-11.5-10.8-11.5
+		c-5.6,0-9.3,3.2-9.3,7.9C1051.8,392.1,1054.5,394.8,1060.1,396.4z"&gt;&lt;/path&gt;
+	&lt;path class="s-path" d="M161,314.5v95c0,43.5,26.5,70.5,69.1,70.5c41.5,0,69.5-28.4,69.5-70.7v-94.8H161z M213.9,352.9c4.5,0,8.1,3.6,8.1,8.1
+		s-3.6,8.1-8.1,8.1s-8.1-3.6-8.1-8.1C205.8,356.6,209.4,352.9,213.9,352.9z M278.9,409.3c0,28.9-16.9,50.1-48.8,50.1
+		c-33.1,0-48.5-19.9-48.5-49.9v-57.2h11.1v57.2c0,12.6,3,22.2,8.9,28.7c6.1,6.7,15.7,10.1,28.5,10.1c24,0,37.8-14.2,37.8-39v-74.2
+		H279v74.2H278.9z"&gt;&lt;/path&gt;
+	&lt;g&gt;
+		&lt;g&gt;
+			&lt;path style="fill:#FFFFFF;" d="M250.4,366.3c-0.1,0-0.2,0-0.4,0c-4.3-0.6-8.7-1-13.1-1.1c-0.9,0-1.8-0.5-2.2-1.4
+				c-0.4-0.8-0.4-1.8,0.1-2.6c4.3-6.5,12.2-10.6,20-10.3c1.4,0,2.5,1.2,2.5,2.6c0,1.4-1.2,2.5-2.6,2.5c-4.4-0.1-8.9,1.5-12.3,4.4
+				c2.8,0.2,5.6,0.5,8.4,0.9c1.4,0.2,2.3,1.5,2.1,2.9C252.7,365.4,251.6,366.3,250.4,366.3z"&gt;&lt;/path&gt;
+		&lt;/g&gt;
+	&lt;/g&gt;
+&lt;/svg&gt;
+
+&lt;/a&gt;
+      &lt;button class='navbar-toggler collapsed gc-search js-gc-search-focus' type='button' data-toggle='collapse' data-target='.gc-nav-primary__search--mobile' aria-controls='gc-nav-primary__search' aria-expanded='false' aria-label='Toggle navigation'&gt;
+
+        &lt;div class='gc-search__icon'&gt;
+          &lt;span&gt;&lt;/span&gt;
+          &lt;span&gt;&lt;/span&gt;
+          &lt;span&gt;&lt;/span&gt;
+        &lt;/div&gt;
+
+      &lt;/button&gt;
+
+      &lt;div class="collapse navbar-collapse bg-white gc-nav-primary__search gc-nav-primary__search--mobile js-mobile-nav"&gt;
+        &lt;form class="gc-search-form js-search-form" role="search" autocomplete="off" action="/search/9chickweedlane" accept-charset="UTF-8" method="get"&gt;&lt;input name="utf8" type="hidden" value="&amp;#x2713;" /&gt;
+  &lt;fieldset class='form-group m-0'&gt;
+    &lt;legend class='sr-only'&gt;GoComics.com - Search Form&lt;/legend&gt;
+    &lt;label class="sr-only" for="search_terms"&gt;Search&lt;/label&gt;
+    &lt;div class='input-group'&gt;
+      &lt;input type="search" name="terms" id="terms" class="form-control gc-search-form__input" placeholder="Search for Your Favorite Comic..." required="required" tabindex="-1" maxlength="50" minlength="1" /&gt;
+      &lt;div class="input-group-append"&gt;
+        &lt;button name="button" type="submit" class="btn btn-sm input-group-text gc-search-form__submit js-search-button" aria-label="Submit Search"&gt;
+          &lt;i class="fa fa-search"&gt;&lt;/i&gt;
+&lt;/button&gt;      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/fieldset&gt;
+&lt;/form&gt;
+      &lt;/div&gt;
+
+
+
+      &lt;div class='collapse navbar-collapse bg-white gc-nav-primary__left-menu js-mobile-nav'&gt;
+        &lt;ul class='navbar-nav'&gt;
+
+          &lt;li class="nav-item dropdown gc-nav-primary__item"&gt;&lt;a class="nav-link dropdown-toggle  gc-nav-primary__link" role="button" aria-haspopup="true" aria-expanded="false" data-link-type="banner-nav-tier-1" data-toggle="dropdown" href="https://www.gocomics.com/comics"&gt;Find Comics&lt;/a&gt;&lt;div class="dropdown-menu rounded-0  gc-nav-primary__dropdown-menu "&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/trending"&gt;Trending Comics&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/political"&gt;Political Cartoons&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/web-comics"&gt;Web Comics&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/categories"&gt;All Categories&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/popular"&gt;Popular Comics&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/a-to-z"&gt;A-Z Comics by Title&lt;/a&gt;
+&lt;/div&gt;&lt;/li&gt;
+
+
+          &lt;li class="nav-item dropdown gc-nav-primary__item"&gt;&lt;a class="nav-link dropdown-toggle  gc-nav-primary__link" role="button" aria-haspopup="true" aria-expanded="false" data-link-type="banner-nav-tier-1" data-toggle="dropdown" href="#"&gt;Best Of&lt;/a&gt;&lt;div class="dropdown-menu rounded-0  gc-nav-primary__dropdown-menu "&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/recommended"&gt;Recommended Comics&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/comics/collections"&gt;Comic Lists&lt;/a&gt;
+            &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://www.gocomics.com/blog"&gt;Blog&lt;/a&gt;
+&lt;/div&gt;&lt;/li&gt;
+
+
+            &lt;li class="nav-item dropdown gc-nav-primary__item"&gt;&lt;a class="nav-link dropdown-toggle  gc-nav-primary__link" role="button" aria-haspopup="true" aria-expanded="false" data-link-type="banner-nav-tier-1" data-toggle="dropdown" href="https://store.gocomics.com/"&gt;Shop&lt;/a&gt;&lt;div class="dropdown-menu rounded-0  gc-nav-primary__dropdown-menu "&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/"&gt;Home&lt;/a&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/product-category/books/"&gt;Books&lt;/a&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/product-category/calendars/"&gt;Calendars&lt;/a&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/product-category/popular-print/"&gt;Comic Prints&lt;/a&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/cart/"&gt;Your Cart&lt;/a&gt;
+              &lt;a class="dropdown-item text-truncate  gc-nav-primary__dropdown-link " data-link-type="header-nav-tier-2" href="https://store.gocomics.com/checkout/"&gt;Checkout&lt;/a&gt;
+&lt;/div&gt;&lt;/li&gt;
+
+
+          &lt;div class="gc-nav-primary__search gc-nav-primary__item--desktop-only"&gt;
+            &lt;form class="gc-search-form js-search-form" role="search" autocomplete="off" action="/search/9chickweedlane" accept-charset="UTF-8" method="get"&gt;&lt;input name="utf8" type="hidden" value="&amp;#x2713;" /&gt;
+  &lt;fieldset class='form-group m-0'&gt;
+    &lt;legend class='sr-only'&gt;GoComics.com - Search Form&lt;/legend&gt;
+    &lt;label class="sr-only" for="search_terms"&gt;Search&lt;/label&gt;
+    &lt;div class='input-group'&gt;
+      &lt;input type="search" name="terms" id="terms" class="form-control gc-search-form__input" placeholder="Search for Your Favorite Comic..." required="required" tabindex="-1" maxlength="50" minlength="1" /&gt;
+      &lt;div class="input-group-append"&gt;
+        &lt;button name="button" type="submit" class="btn btn-sm input-group-text gc-search-form__submit js-search-button" aria-label="Submit Search"&gt;
+          &lt;i class="fa fa-search"&gt;&lt;/i&gt;
+&lt;/button&gt;      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/fieldset&gt;
+&lt;/form&gt;
+          &lt;/div&gt;
+
+
+
+
+            &lt;div class="gc-nav-primary__authentication"&gt;
+              &lt;li class="nav-item gc-nav-primary__item"&gt;&lt;a rel="nofollow" class="nav-link  gc-nav-primary__link" data-link-type="header-nav-tier-1" href="https://www.gocomics.com/profiles/sign-in"&gt;Sign In&lt;/a&gt;&lt;/li&gt;
+              &lt;li class="nav-item gc-nav-primary__item"&gt;&lt;a rel="nofollow" class="nav-link  gc-nav-primary__link" data-link-type="header-nav-tier-1" href="https://www.gocomics.com/help/why-upgrade-to-premium-ad-free-subscription"&gt;Free Trial&lt;/a&gt;&lt;/li&gt;
+            &lt;/div&gt;
+        &lt;/ul&gt;
+      &lt;/div&gt;
+
+    &lt;/nav&gt;
+
+  &lt;/header&gt;
+&lt;/div&gt;&lt;!-- End Site Header --&gt;
+
+      &lt;div id='cookieconsent-container'&gt;&lt;/div&gt;
+
+
+      &lt;noscript&gt;
+        &lt;div class="amu-container-layout gc-no-js"&gt;
+          
+&lt;div class='amu-container-alert'&gt;
+  &lt;div class="alert alert-dismissible fade show gc-alert gc-alert--error js-gc-alert" role="alert"&gt;
+    &lt;strong&gt;Oh snap!&lt;/strong&gt; GoComics needs JavaScript to work, please enable JavaScript in your browser settings.
+    &lt;button type="button" class="close js-gc-alert-close" data-dismiss="alert" aria-label="Close"&gt;
+      &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
+    &lt;/button&gt;
+&lt;/div&gt;&lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/noscript&gt;
+
+      &lt;div role="main" class="gc-page-container"&gt;
+
+
+
+        
+
+  
+
+  &lt;div class='gc-container gc-container--fluid'&gt;
+    &lt;div class='layout-2col layout-2col--comic'&gt;
+
+      &lt;div class="layout-2col-sidebar bg-white border-right js-gc-lock-parent hidden-md-down"&gt;
+        &lt;aside class="gc-feature-side"&gt;
+  &lt;div class="gc-fade-bottom"&gt;
+    &lt;picture class="card-img lazyload__padder lazyload__padder--card"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://avatar.amuniversal.com/feature_avatars/recommendation_images/features/cw/large_rec-201701251556.jpg 600w, https://avatar.amuniversal.com/feature_avatars/recommendation_images/features/cw/mid_rec-201701251556.jpg 300w, https://avatar.amuniversal.com/feature_avatars/recommendation_images/features/cw/small_rec-201701251556.jpg 150w" sizes="auto" width="100%" alt="#&amp;lt;Feature:0x00007f65f0f5d1f8&amp;gt;" src="https://avatar.amuniversal.com/feature_avatars/recommendation_images/features/cw/large_rec-201701251556.jpg" /&gt;&lt;/picture&gt;
+  &lt;/div&gt;
+  &lt;div class="gc-feature-side__info"&gt;
+    &lt;a class="gc-blended-link gc-blended-link--primary" href="/9chickweedlane"&gt;
+      
+
+
+&lt;div class='media amu-media-item'&gt;
+  &lt;div class='media-left'&gt;
+    &lt;div class="gc-avatar gc-avatar--creator xs"&gt;&lt;img srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/small_u-201701251613.png, 72w" class="lazyload" alt="9 Chickweed Lane" src="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/small_u-201701251613.png" /&gt;&lt;/div&gt;
+  &lt;/div&gt;
+  &lt;div class='media-body ml-3'&gt;
+    &lt;h2 class='media-heading h4 mb-0'&gt;9 Chickweed Lane&lt;/h2&gt;
+    &lt;span class="media-subheading small"&gt;By Brooke McEldowney&lt;/span&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;/a&gt;    &lt;div class="gc-feature-side__follow js-subscription-feature-358"&gt;
+    &lt;a class="btn btn-primary btn-block" data-toggle="modal" data-tooltip="tooltip" data-target="#js-modal-account-hook" data-modal-message="Sign up or sign in to add comics to your comics page." aria-label="Sign up or sign in to add 9 Chickweed Lane to your Comics I Follow" title="Sign up or sign in to add 9 Chickweed Lane to your Comics I Follow" rel="nofollow" href=""&gt;
+      Follow
+&lt;/a&gt;&lt;/div&gt;
+
+  &lt;/div&gt;
+&lt;/aside&gt;
+          &lt;div class='js-gc-lock-target'&gt;
+            
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-tower_nav-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="tower_nav" class="js-ad js-ad-refresh gc-ad ad-tower_nav" data-ad-type="tower_nav"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+          &lt;/div&gt;
+      &lt;/div&gt;
+
+      &lt;div class="layout-2col-content content-section-padded"&gt;
+
+        &lt;div class="gc-feature-header"&gt;
+  &lt;div class="gc-feature-header__info"&gt;
+    &lt;!-- Media Object --&gt;
+    &lt;a class="gc-blended-link gc-blended-link--primary" href="/9chickweedlane"&gt;
+      
+
+
+&lt;div class='media amu-media-item'&gt;
+  &lt;div class='media-left'&gt;
+    &lt;div class="gc-avatar gc-avatar--creator xs"&gt;&lt;img srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/small_u-201701251613.png, 72w" class="lazyload" alt="9 Chickweed Lane" src="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/small_u-201701251613.png" /&gt;&lt;/div&gt;
+  &lt;/div&gt;
+  &lt;div class='media-body ml-3'&gt;
+    &lt;h4 class='media-heading h4 mb-0'&gt;9 Chickweed Lane&lt;/h4&gt;
+    &lt;span class="media-subheading small"&gt;By Brooke McEldowney&lt;/span&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;/a&gt;    &lt;!-- Follow Button --&gt;
+    &lt;div class="gc-feature-side__follow js-subscription-feature-358"&gt;
+    &lt;a class="btn btn-primary btn-block" data-toggle="modal" data-tooltip="tooltip" data-target="#js-modal-account-hook" data-modal-message="Sign up or sign in to add comics to your comics page." aria-label="Sign up or sign in to add 9 Chickweed Lane to your Comics I Follow" title="Sign up or sign in to add 9 Chickweed Lane to your Comics I Follow" rel="nofollow" href=""&gt;
+      Follow
+&lt;/a&gt;&lt;/div&gt;
+
+  &lt;/div&gt;
+&lt;/div&gt;
+
+        
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-leaderboard_feature_item-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="leaderboard_feature_item" class="js-ad js-ad-refresh gc-ad ad-leaderboard_feature_item" data-ad-type="leaderboard_feature_item"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+        &lt;nav class='content-section-padded-sm'&gt;
+  &lt;ul class='nav nav-tabs gc-tab-nav js-tab-nav' style="visibility: hidden;"&gt;
+    &lt;li class="nav-item"&gt;&lt;a class="nav-link " data-link="overview" href="/9chickweedlane"&gt;Overview&lt;/a&gt;&lt;/li&gt;
+    &lt;li class="nav-item"&gt;&lt;a class="nav-link active" data-link="comics" href="/9chickweedlane/2019/07/16"&gt;Comics&lt;/a&gt;&lt;/li&gt;
+    &lt;li class="nav-item"&gt;&lt;a class="nav-link " data-link="about" href="/9chickweedlane/about"&gt;About&lt;/a&gt;&lt;/li&gt;
+    
+  &lt;/ul&gt;
+&lt;/nav&gt;
+
+
+
+        
+  &lt;div class="gc-container"&gt;
+    &lt;h1 class="m-0 h6 text-center"&gt;9 Chickweed Lane by Brooke McEldowney for July 16, 2019&lt;/h1&gt;
+    
+
+
+&lt;div class="comic container js-comic-2770123 js-item-init js-item-share js-comic-swipe bg-white border rounded" data-shareable-model="FeatureItem"
+data-shareable-id="2770123"
+data-transcript=""
+data-id="2770123"
+data-feature-id="358"
+data-feature-name="9 Chickweed Lane"
+data-feature-code="cw"
+data-feature-type="comic"
+data-feature-format="print"
+data-date="2019-07-16"
+data-formatted-date="July 16, 2019"
+data-url="https://www.gocomics.com/9chickweedlane/2019/07/16"
+data-creator="Brooke McEldowney"
+data-title="9 Chickweed Lane for July 16, 2019 | GoComics.com"
+data-tags=""
+data-description="For July 16, 2019"
+data-image="https://assets.amuniversal.com/d4571e307e420137a88c005056a9545d"
+itemtype="http://schema.org/CreativeWork"
+accountableperson="Andrews McMeel Universal"
+creator="Brooke McEldowney"&gt;
+
+  &lt;div class='comic__wrapper'&gt;
+
+    
+
+    
+
+    &lt;div class='comic__container'&gt;
+
+
+      &lt;div class="comic__image js-comic-swipe-target"&gt;
+        &lt;div class="swipe-preview swipe-preview__previous js-preview-previous"&gt;
+  &lt;div class='swipe-preview__group'&gt;
+    &lt;h5 class='card-subtitle'&gt;
+        &lt;date&gt;July 15, 2019&lt;/date&gt;
+    &lt;/h5&gt;
+    &lt;div class='swipe-preview__ubadge'&gt;
+      &lt;div class="gc-avatar gc-avatar--creator sm"&gt;&lt;img srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/mid_u-201701251613.png, 137w" class="lazyload" alt="9 Chickweed Lane" src="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/mid_u-201701251613.png" /&gt;&lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+        &lt;a itemprop='image' class="js-item-comic-link" href="/9chickweedlane/2019/07/16" title="9 Chickweed Lane"&gt;
+
+  &lt;picture class="item-comic-image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://assets.amuniversal.com/d4571e307e420137a88c005056a9545d 900w" sizes="
+                       (min-width: 992px) 900px,
+                       (min-width: 768px) 600px,
+                       (min-width: 576px) 300px,
+                       900px" width="100%" alt="9 Chickweed Lane Comic Strip for July 16, 2019 " src="https://assets.amuniversal.com/d4571e307e420137a88c005056a9545d" /&gt;&lt;/picture&gt;
+&lt;/a&gt;
+&lt;meta itemprop='isFamilyFriendly' content='true'&gt;
+        &lt;div class="swipe-preview swipe-preview__next js-preview-next"&gt;
+  &lt;div class='swipe-preview__group'&gt;
+    &lt;h5 class='card-subtitle'&gt;
+        All caught up!
+    &lt;/h5&gt;
+    &lt;div class='swipe-preview__ubadge'&gt;
+      &lt;div class="gc-avatar gc-avatar--creator sm"&gt;&lt;img srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/mid_u-201701251613.png, 137w" class="lazyload" alt="9 Chickweed Lane" src="https://avatar.amuniversal.com/feature_avatars/ubadge_images/features/cw/mid_u-201701251613.png" /&gt;&lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+      &lt;/div&gt;
+
+        &lt;nav class="gc-calendar-nav" role="group" aria-label="Date Navigation Controls"&gt;
+    &lt;div class="gc-calendar-nav__previous"&gt;
+      &lt;a role='button' href='/9chickweedlane/1993/07/12' class='fa btn btn-outline-secondary btn-circle fa fa-backward sm ' title='' &gt;&lt;/a&gt;
+      &lt;a role='button' href='/9chickweedlane/2019/07/15' class='fa btn btn-outline-secondary btn-circle fa-caret-left sm js-previous-comic ' title='' &gt;&lt;/a&gt;
+    &lt;/div&gt;
+    &lt;div class="gc-calendar-nav__select"&gt;
+      &lt;div class="btn btn-outline-secondary gc-calendar-nav__datepicker js-calendar-wrapper"
+           data-date="2019/07/16"
+           data-name="/9chickweedlane/"
+           data-year="2019"
+           data-month="07"
+           data-day="16"
+           data-feature="9chickweedlane"
+           data-ct=""
+           data-start="1993/07/12"
+           data-end="2019/07/16"
+           data-open="2019-07-16"&gt;
+          &lt;i class="fa fa-calendar xs"&gt;&lt;/i&gt;
+          &lt;input type="text" name="startDate" placeholder="July 16, 2019" readonly="readonly" class="cal off calendar-input date js-calendar-input datepicker js-calendar-input-link"&gt;
+      &lt;/div&gt;
+      &lt;a class="btn btn-outline-secondary" alt="Click to View a Random 9 Chickweed Lane Comic Strip!" href="/random/9chickweedlane"&gt;Random&lt;/a&gt;
+    &lt;/div&gt;
+    &lt;div class="gc-calendar-nav__next"&gt;
+      &lt;a role='button' href='' class='fa btn btn-outline-secondary btn-circle fa-caret-right sm disabled' title='' &gt;&lt;/a&gt;
+      &lt;a role='button' href='' class='fa btn btn-outline-secondary btn-circle fa-forward sm disabled' title='' &gt;&lt;/a&gt;
+    &lt;/div&gt;
+&lt;/nav&gt;
+
+
+    &lt;/div&gt;
+
+      &lt;div class="comic__interactions-container js-gc-lock-parent js-item-interactions-container "&gt;
+        &lt;div class="item-interactions js-gc-lock-target js-share-button-container dropdown" id="toolbar_2770123" data-gc-lock-depends="leaderboard_feature_item"&gt;
+  
+  &lt;div class='js-like'&gt;
+    &lt;a class="gc-icon fa fa-heart md" data-toggle="modal" data-target="#js-modal-account-hook" aria-label="Sign in to like this comic." title="Sign in to like this comic." data-tooltip="tooltip" rel="nofollow" href=""&gt;&lt;/a&gt;
+
+  &lt;span id="interaction_count_likes_2770123"  class="js-interaction-count h6 text-center interaction-count likes"&gt;125&lt;/span&gt;
+&lt;/div&gt;
+  &lt;div class=" js-favorite"&gt;
+    &lt;a class="gc-icon fa fa-thumb-tack md" data-toggle="modal" data-target="#js-modal-account-hook" data-modal-message="Sign up or sign in to add this to your Saved Comic Strips." title="Sign up or sign in to add to your Saved Comic Strips" data-tooltip="tooltip" rel="nofollow" href="#"&gt;&lt;/a&gt;
+  &lt;span id="interaction_count_favorites_2770123"  class="js-interaction-count h6 text-center interaction-count favorites"&gt;8&lt;/span&gt;
+&lt;/div&gt;
+  
+&lt;a class="js-facebook js-share-button gc-icon fa btn fa-facebook md" aria-label="Share on Facebook" data-tooltip="tooltip" title="Share on Facebook" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+&lt;a class="js-twitter js-share-button gc-icon fa btn fa-twitter md" aria-label="Share on Twitter" data-tooltip="tooltip" title="Share on Twitter" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+
+&lt;a role='button' href class='gc-icon fa fa-ellipsis-h md' data-toggle='dropdown' aria-label='More sharing options' data-tooltip='tooltip' title="More Sharing Options"&gt;&lt;/a&gt;
+
+&lt;div class='gc-share__dropdown dropdown-menu dropdown-menu-right'&gt;
+  &lt;div class='gc-share__social-links'&gt;
+    &lt;a class="js-reddit js-share-button gc-icon fa btn fa-reddit md" aria-label="Share on Reddit" data-tooltip="tooltip" title="Share on Reddit" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+    &lt;a class="js-google-plus js-share-button gc-icon fa btn fa-google-plus md" aria-label="Share on Google Plus" data-tooltip="tooltip" title="Share on Google Plus" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+    &lt;a class="js-tumblr js-share-button gc-icon fa btn fa-tumblr md" aria-label="Share on Tumblr" data-tooltip="tooltip" title="Share on Tumblr" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+    &lt;a class="js-pinterest js-share-button gc-icon fa btn fa-pinterest md" aria-label="Share on Pinterest" data-tooltip="tooltip" title="Share on Pinterest" role="button" rel="no-follow" href="#"&gt;&lt;/a&gt;
+
+    &lt;a aria-label="Share via email" title="Share via email" data-tooltip="tooltip" class="js-email js-share-button gc-icon fa btn fa-envelope md" href="mailto:?body=https%3A%2F%2Fwww.gocomics.com%2F9chickweedlane%2F2019%2F07%2F16&amp;amp;subject=Read%209%20Chickweed%20Lane%20by%20Brooke%20McEldowney%20on%20GoComics.com%20%7C%20July%2016%2C%202019"&gt;
+&lt;/a&gt;  &lt;/div&gt;
+
+  &lt;form class='text-center'&gt;
+    &lt;fieldset&gt;
+      &lt;legend class="sr-only"&gt;Share this - Copy link&lt;/legend&gt;
+      &lt;label class='gc-font-secondary' for="link-2770123" aria-label="link-2770123"&gt;
+        Share Link
+      &lt;/label&gt;
+      &lt;input class='js-copy-link form-control' id="link-2770123" value="https://www.gocomics.com/9chickweedlane/2019/07/16" aria-label='Get the permalink' data-clipboard-target="#link-2770123"&gt;
+    &lt;/fieldset&gt;
+  &lt;/form&gt;
+&lt;/div&gt;
+&lt;/div&gt;
+
+      &lt;/div&gt;
+
+  &lt;/div&gt;
+
+    &lt;div class='comic__buy-button'&gt;
+      &lt;a class="btn btn-primary gc-button" alt="Buy a Print of This Comic" data-link-type="feature-item-buy-print" href="https://store.gocomics.com/product/custom-print-order?publish_date=20190716&amp;amp;feature_code=cw&amp;amp;featureName=9 Chickweed Lane&amp;amp;hash=d4571e307e420137a88c005056a9545d"&gt;Buy a Print of This Comic&lt;/a&gt;
+      &lt;a class="btn btn-outline-primary gc-button" alt="Buy a Print of This Comic" data-link-type="feature-item-license" href="https://licensing.andrewsmcmeel.com/features/cw?date=2019-07-16"&gt;License This Comic&lt;/a&gt;
+    &lt;/div&gt;
+
+&lt;/div&gt;
+
+
+
+
+        &lt;h2 class="gc-section-title-more text-center content-section-sm"&gt;More From 9 Chickweed Lane&lt;/h2&gt;
+        
+
+&lt;div class='row'&gt;
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_self" href="https://www.gocomics.com/9chickweedlane"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_cap_flare_201705121044.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_cw_cap_flare_201705121044.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_cw_cap_flare_201705121044.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_cap_flare_201705121044.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Rita_promo_201901081106.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_Rita_promo_201901081106.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_Rita_promo_201901081106.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Rita_promo_201901081106.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--is-ad"&gt;
+          &lt;section class='card gc-card gc-card--ad-rectangle group-item-ad'&gt;
+            
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-rectangle-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="rectangle1" class="js-ad-lazy-load js-ad-refresh gc-ad ad-rectangle" data-ad-type="rectangle1"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+          &lt;/section&gt;
+      &lt;/div&gt;
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Gross_promo_201901081112.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_Gross_promo_201901081112.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_Gross_promo_201901081112.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Gross_promo_201901081112.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Brussels_promo_201901081115.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_Brussels_promo_201901081115.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_Brussels_promo_201901081115.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Brussels_promo_201901081115.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_allied_spy_740x700.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_cw_allied_spy_740x700.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_cw_allied_spy_740x700.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_allied_spy_740x700.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_CatBreath_promo_201901080851.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_CatBreath_promo_201901080851.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_CatBreath_promo_201901080851.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_CatBreath_promo_201901080851.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_PibgornPoltergise_201901080857.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_PibgornPoltergise_201901080857.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_PibgornPoltergise_201901080857.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_PibgornPoltergise_201901080857.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--is-ad"&gt;
+          &lt;section class='card gc-card gc-card--ad-rectangle group-item-ad'&gt;
+            
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-rectangle-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="rectangle2" class="js-ad-lazy-load js-ad-refresh gc-ad ad-rectangle" data-ad-type="rectangle2"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+          &lt;/section&gt;
+      &lt;/div&gt;
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_PubertyDetonation_promo_201901080859.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_PubertyDetonation_promo_201901080859.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_PubertyDetonation_promo_201901080859.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_PubertyDetonation_promo_201901080859.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Sonata_promo_201901081100.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_Sonata_promo_201901081100.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_Sonata_promo_201901081100.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_Sonata_promo_201901081100.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_14_Dumpster_201902080835.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_14_Dumpster_201902080835.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_14_Dumpster_201902080835.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_14_Dumpster_201902080835.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_5_Crud_promo_201902080845.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_5_Crud_promo_201902080845.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_5_Crud_promo_201902080845.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_5_Crud_promo_201902080845.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_7_Satan_promo_201902080846.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_7_Satan_promo_201902080846.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_7_Satan_promo_201902080846.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_7_Satan_promo_201902080846.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_12_Borgia_promo_201902080848.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_12_Borgia_promo_201902080848.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_12_Borgia_promo_201902080848.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_12_Borgia_promo_201902080848.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_13_MSND_promo_201902080849.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_13_MSND_promo_201902080849.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_13_MSND_promo_201902080849.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_13_MSND_promo_201902080849.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://pibpress.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_10_CoffeeCup_Promo_201902080847.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_10_CoffeeCup_Promo_201902080847.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_10_CoffeeCup_Promo_201902080847.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_10_CoffeeCup_Promo_201902080847.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://thecelebritycafe.com/2017/01/interview-9-chickweed-lanepibgorn-comics-creator-brooke-mceldowney/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_w_title_large_cw_McEldowney-interview-link-art.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_w_title_mid_cw_McEldowney-interview-link-art.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_w_title_small_cw_McEldowney-interview-link-art.jpg 150w" sizes="auto" width="100%" alt="Interview with ‘9 Chickweed Lane/Pibgorn’ comics creator Brooke McEldowney" src="//assets.gocomics.com/uploads/features/cw/widgets/link_w_title_large_cw_McEldowney-interview-link-art.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+    &lt;div class="card-body gc-card__body"&gt;
+      
+
+&lt;h4 class="card-title"&gt;Interview with ‘9 Chickweed Lane/Pibgorn’ comics creator Brooke McEldowney&lt;/h4&gt;
+
+&lt;h5 class="card-subtitle text-muted"&gt;LINK&lt;/h5&gt;
+      
+      
+      
+      
+
+
+
+
+
+
+    &lt;/div&gt;
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" target="_blank" href="http://chickweedcafe.blogspot.com/"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_blog_740x700.jpg 600w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_mid_cw_cw_blog_740x700.jpg 300w, //assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_small_cw_cw_blog_740x700.jpg 150w" sizes="auto" width="100%" alt="" src="//assets.gocomics.com/uploads/features/cw/widgets/link_wo_title_large_cw_cw_blog_740x700.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" href="/blog/3170/brooke-mceldowney-9-chickweed-lane-pibgorn"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image lazyload__padder lazyload__padder--card"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/default_images/default_image_large_meet_your_creator_meetyourcreator-generic.jpg 600w, //assets.gocomics.com/uploads/default_images/default_image_mid_meet_your_creator_meetyourcreator-generic.jpg 300w, //assets.gocomics.com/uploads/default_images/default_image_small_meet_your_creator_meetyourcreator-generic.jpg 150w" sizes="auto" width="100%" alt="Brooke McEldowney (9 Chickweed Lane, Pibgorn)" src="//assets.gocomics.com/uploads/default_images/default_image_large_meet_your_creator_meetyourcreator-generic.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+    &lt;div class="card-body gc-card__body"&gt;
+      
+
+&lt;h4 class="card-title"&gt;Brooke McEldowney (9 Chickweed Lane, Pibgorn)&lt;/h4&gt;
+
+&lt;h5 class="card-subtitle text-muted"&gt;GoComics&lt;/h5&gt;
+      
+      
+      
+      &lt;p class="card-text text-muted"&gt;October 04, 2014&lt;/p&gt;
+
+
+
+
+
+
+    &lt;/div&gt;
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+
+
+      &lt;div class="gc-deck gc-deck--third gc-deck--has-ads"&gt;
+          &lt;a class="gc-blended-link gc-blended-link--primary" href="/blog/4428/see-no-10-in-gocomics-top-10-most-read-for-2017"&gt;
+            
+&lt;div class="card gc-card gc-card--on-hover"&gt;
+
+
+    &lt;div class="card-img-top gc-card__image-wrapper "&gt;
+
+      
+  &lt;picture class="gc-card__image lazyload__padder lazyload__padder--card"&gt;&lt;img class="lazyload img-fluid" srcset="https://assets.gocomics.com/assets/transparent-3eb10792d1f0c7e07e7248273540f1952d9a5a2996f4b5df70ab026cd9f05517.png" data-srcset="//assets.gocomics.com/uploads/blogs/blog_image_large_4428_10884_9cwl_blog_post_201801041045.jpg 600w, //assets.gocomics.com/uploads/blogs/blog_image_mid_4428_10884_9cwl_blog_post_201801041045.jpg 300w, //assets.gocomics.com/uploads/blogs/blog_image_small_4428_10884_9cwl_blog_post_201801041045.jpg 150w" sizes="auto" width="100%" alt="See No. 10 in GoComics&amp;#39; Top-10 Most-Read for 2017" src="//assets.gocomics.com/uploads/blogs/blog_image_large_4428_10884_9cwl_blog_post_201801041045.jpg" /&gt;&lt;/picture&gt;
+
+
+
+      &lt;div class='gc-card__image gc-card__image--overlay'&gt;&lt;/div&gt;
+    &lt;/div&gt;
+
+
+    &lt;div class="card-body gc-card__body"&gt;
+      
+
+&lt;h4 class="card-title"&gt;See No. 10 in GoComics' Top-10 Most-Read for 2017&lt;/h4&gt;
+
+&lt;h5 class="card-subtitle text-muted"&gt;John Glynn&lt;/h5&gt;
+      
+      
+      
+      &lt;p class="card-text text-muted"&gt;January 08, 2018&lt;/p&gt;
+
+
+
+
+
+
+    &lt;/div&gt;
+
+&lt;/div&gt;
+            
+&lt;/a&gt;      &lt;/div&gt;
+
+&lt;/div&gt;
+  &lt;/div&gt;
+
+
+
+
+      &lt;/div&gt;
+
+    &lt;/div&gt;
+  &lt;/div&gt;
+
+    &lt;div id='recommendations_holder' class='js-post-load-init' data-url="/favorites/recommendations.js?short_name=9chickweedlane"&gt;&lt;/div&gt;
+
+  
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-tynt-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="tynt" class="js-ad js-ad-refresh gc-ad ad-tynt" data-ad-type="tynt"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+
+
+
+      &lt;/div&gt;
+
+      
+&lt;div class="amu-container-ad-wrapper js-destructable fixed-ad-bottom fixed-ad-bottom--banner js-ad-banner-lock-wrapper ad-hidden"&gt;
+	&lt;div class="amu-container-ad ad-banner-lock-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="banner_lock" class="js-ad js-ad-refresh gc-ad ad-banner-lock" data-ad-type="banner_lock"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+      
+&lt;div class="amu-container-ad-wrapper   "&gt;
+	&lt;div class="amu-container-ad ad-banner-bottom-container"&gt;
+    &lt;div class="ad-header"&gt;Advertisement&lt;/div&gt;
+	  &lt;div id="banner_bot" class="js-ad-lazy-load js-ad-refresh gc-ad ad-banner-bottom" data-ad-type="banner_bot"&gt;
+	  &lt;/div&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;footer class="gc-page gc-page--gutters-none gc-footer bg-white"&gt;
+  &lt;div class="gc-page__full"&gt;
+    &lt;div class="container gc-footer__links"&gt;
+      &lt;div class="gc-content"&gt;
+        
+          &lt;div class="gc-content__4col"&gt;
+            &lt;h5 class='text-muted font-weight-normal'&gt;Find Comics&lt;/h5&gt;
+            &lt;ul class='gc-footer__list'&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/comics/trending"&gt;Trending&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/comics/political"&gt;Political Cartoons&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/comics/web-comics"&gt;Web Comics&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="/comics/categories"&gt;All Categories&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/comics/popular"&gt;Popular Comics&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/comics/a-to-z"&gt;A-Z Comics by Title&lt;/a&gt;&lt;/li&gt;
+              &lt;!--&lt;li&gt;&lt;/li&gt;--&gt;
+              &lt;!--&lt;li&gt;&lt;/li&gt;--&gt;
+            &lt;/ul&gt;
+          &lt;/div&gt;
+          
+          &lt;div class="gc-content__4col"&gt;
+            &lt;h5 class='text-muted font-weight-normal'&gt;More GoComics&lt;/h5&gt;
+            &lt;ul class='gc-footer__list'&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/blog"&gt;GoComics Blog&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" target="_blank" data-link-type="footer-nav" href="http://www.comicssherpa.com/site/index"&gt;Visit Comics Sherpa&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" target="_blank" data-link-type="footer-nav" href="http://www.facebook.com/gocomics"&gt;GC on Facebook&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" target="_blank" data-link-type="footer-nav" href="http://www.twitter.com/gocomics"&gt;GC on Twitter&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" target="_blank" data-link-type="footer-nav" href="http://www.instagram.com/gocomics"&gt;GC on Instagram&lt;/a&gt;&lt;/li&gt;
+                &lt;li&gt;&lt;a class="gc-footer__item" target="_blank" data-link-type="footer-nav" href="https://store.gocomics.com/"&gt;Shop&lt;/a&gt;&lt;/li&gt;
+            &lt;/ul&gt;
+          &lt;/div&gt;
+
+        &lt;div class="gc-content__4col"&gt;
+          &lt;h5 class="text-muted font-weight-normal"&gt;Account&lt;/h5&gt;
+          &lt;ul class="gc-footer__list"&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" rel="nofollow" data-link-type="footer-nav" href="https://www.gocomics.com/help/why-upgrade-to-premium-ad-free-subscription"&gt;Free Trial&lt;/a&gt;&lt;/li&gt;
+              &lt;li&gt;&lt;a class="gc-footer__item" rel="nofollow" data-link-type="footer-nav" href="https://www.gocomics.com/profiles/sign-in"&gt;Sign in&lt;/a&gt;&lt;/li&gt;
+
+            &lt;li&gt;&lt;a class="gc-footer__item" rel="nofollow" data-link-type="footer-nav" href="https://www.gocomics.com/profiles/gift-subscription"&gt;Gift Premium&lt;/a&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a class="gc-footer__item" rel="nofollow" data-link-type="footer-nav" href="https://www.gocomics.com/profiles/gift-subscription/redeem"&gt;Redeem a Gift&lt;/a&gt;&lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/div&gt;
+
+        &lt;div class="gc-content__4col"&gt;
+          &lt;h5 class="text-muted font-weight-normal"&gt;About&lt;/h5&gt;
+          &lt;ul class="gc-footer__list"&gt;
+            &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/help/about"&gt;About GoComics&lt;/a&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/help"&gt;Help &amp;amp; FAQ&lt;/a&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/help/advertising"&gt;Advertising&lt;/a&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a class="gc-footer__item" data-link-type="footer-nav" href="https://www.gocomics.com/help/contact"&gt;Contact Us&lt;/a&gt;&lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;!-- /.gc-footer --&gt;
+    
+    &lt;div class="gc-footer__copyright"&gt;
+      &lt;span&gt;
+        &amp;copy; Copyright
+          9 Chickweed Lane, © Brooke McEldowney&lt;br class="d-sm-none"/&gt;
+        2019. All Rights Reserved.
+        &lt;a class="gc-footer__copyright-link" data-link-type="footer-nav" href="https://www.gocomics.com/help/terms"&gt;Terms &amp;amp; Conditions&lt;/a&gt;
+        -
+        &lt;a target="_blank" class="gc-footer__copyright-link" data-link-type="footer-nav" href="//www.andrewsmcmeel.com/privacy-policy"&gt;Privacy Policy&lt;/a&gt;
+      &lt;/span&gt;
+    &lt;/div&gt;&lt;!-- /.footer-copyright --&gt;
+  &lt;/div&gt;
+&lt;/footer&gt;&lt;!-- /.amu-container-footer --&gt;
+    &lt;/div&gt;
+
+      
+&lt;div class="modal fade" id="js-modal-account-hook" tabindex="-1" role="dialog" aria-labelledby="Join GoComics!" aria-hidden="true"&gt;
+  &lt;div class="modal-dialog" role="document"&gt;
+    &lt;div class="modal-content bg-info text-white"&gt;
+      &lt;div class="modal-header"&gt;
+        &lt;div class="modal-title h2"&gt;You must have an account to access this feature&lt;/div&gt;
+        &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
+          &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
+        &lt;/button&gt;
+      &lt;/div&gt;
+      &lt;div class="modal-body text-center"&gt;
+
+          &lt;a class="btn btn-light gc-button" data-link-type="modal-account-hook" href="/profiles/sign-in"&gt;Sign in&lt;/a&gt;
+          &lt;a class="btn btn-outline-light gc-button" data-link-type="modal-account-hook" href="/profiles/sign-up?account_type=free"&gt;Sign up for free&lt;/a&gt;
+          &lt;a class="btn btn-outline-light gc-button" data-link-type="modal-account-hook" href="/help/why-upgrade-to-premium-ad-free-subscription"&gt;Free Trial&lt;/a&gt;
+
+
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+
+    &lt;script src="https://assets.gocomics.com/assets/application-gc-postload-38c495659fa74c6bdbdef491358d7e8770448401a22883e612c250e793eba21f.js"&gt;&lt;/script&gt;
+
+    
+
+    &lt;script src="https://assets.gocomics.com/assets/apollo-8d36fd370ca1a24d2d6322970a4b520718a53c12ea96b5e6d85090ecb4f11d93.js?sampling=100"&gt;&lt;/script&gt;
+
+    &lt;div class="amu-layout-size"&gt;
+	&lt;span class="js-layout-size-xl d-none d-xl-block"&gt;&lt;/span&gt;
+	&lt;span class="js-layout-size-lg d-none d-lg-block d-xl-none"&gt;&lt;/span&gt;
+  &lt;span class="js-layout-size-md d-none d-md-block d-lg-none"&gt;&lt;/span&gt;
+  &lt;span class="js-layout-size-sm d-none d-sm-block d-md-none"&gt;&lt;/span&gt;
+  &lt;span class="js-layout-size-xs d-block d-sm-none"&gt;&lt;/span&gt;
+&lt;/div&gt;
+
+    &lt;a class="btn btn-secondary gc-back-to-top" href="#top"&gt;&lt;i class='gc-icon gc-icon-fluid fa fa-caret-up sm'&gt;&lt;/i&gt; Back To Top&lt;/a&gt;
+
+  &lt;/body&gt;
+&lt;/html&gt;
+</ReturnValue>
+    <OutAndRefValues />
+  </RecordedCall>
+</ArrayOfRecordedCall>

--- a/tests/SendComics.IntegrationTests/RecordedCalls/TwoSubscribersOneEmphatic_BuildsOneMailForEmphatic.xml
+++ b/tests/SendComics.IntegrationTests/RecordedCalls/TwoSubscribersOneEmphatic_BuildsOneMailForEmphatic.xml
@@ -1,0 +1,2525 @@
+<?xml version="1.0"?>
+<ArrayOfRecordedCall xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <RecordedCall>
+    <Method>System.String GetContent(System.Uri)</Method>
+    <ReturnValue xsi:type="xsd:string">&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+  &lt;title&gt;Homepage | Dilbert by Scott Adams&lt;/title&gt;
+  &lt;link href='https://fonts.googleapis.com/css?family=Raleway:800' rel='stylesheet' type='text/css'&gt;
+  &lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-57x57-e0b4e5677903a73270dfdbbdf453822ec6f41670be1e04b72bc50ba1a7190452.png" sizes="57x57" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-114x114-4df35bbdab93b653a1b2f7b87339b7275ae0bf5cd2405ef0039a9bf767a89672.png" sizes="114x114" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-72x72-32ed2d8b00c89f8970de5868ef96f918328d9ae53c09c16ff7c141557919d050.png" sizes="72x72" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-144x144-cbf35f76ba876c6bc1c2bf036ab7dcb680d39adfcc926e2f3f805a9bbfa3c421.png" sizes="144x144" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-60x60-99fbd11d8f9549f0b27a7bc6886299c887c3a5d70cc16ce57248c204ee06619f.png" sizes="60x60" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-120x120-9f04dc1f1f49ed25b3ab07923f434750424bf94a06ef51cbbec340e8ce6d71c7.png" sizes="120x120" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-76x76-ae33c10c412af3059d008a78a3b9230ed9acbfe3cff0ea779d34595ced8f18cd.png" sizes="76x76" /&gt;
+&lt;link rel="apple-touch-icon" type="image/png" href="/assets/favicon/apple-touch-icon-152x152-45e8cce5279b39b468df54735e23a403775ef5e55a28ca1f90b5c2ba5fc5a1f1.png" sizes="152x152" /&gt;
+&lt;link rel="icon" type="image/png" href="/assets/favicon/favicon-196x196-cf4d86b485e628a034ab8b961c1c3520b5969252400a80b9eed544d99403e037.png" sizes="196x196" /&gt;
+&lt;link rel="icon" type="image/png" href="/assets/favicon/favicon-160x160-3ea5e996022211d066e9ce9ac4f17b398f59116ff5954986a60d8b022a871238.png" sizes="160x160" /&gt;
+&lt;link rel="icon" type="image/png" href="/assets/favicon/favicon-96x96-c82238e3f09749e48ac48a4b3b49b0fa88e485e6303c5be727c026d32843841f.png" sizes="96x96" /&gt;
+&lt;link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32-d68bbf274659c3a17c78e06e7cedc102423d49707228292768bc433599f4bdd9.png" sizes="32x32" /&gt;
+&lt;link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16-02c369cb01fd85c99a5d8a3c113aba4178e35db3680a89be5df48cd49b47d8a1.png" sizes="16x16" /&gt;
+&lt;link rel="shortcut icon" type="image/x-icon" href="/assets/favicon/favicon-018fc74a59c534d43442c3893ac35b4771efa080c16159257bede9a46a798d0b.ico" /&gt;
+&lt;meta name="msapplication-TileColor" content="#ffffff" /&gt;
+&lt;meta name="msapplication-TileImage" content="/assets/favicon/mstile-144x144-b6ab8a12c34e35c1e7587ba2662654ebf5be75fa53e15a130105d1838df90d23.png" /&gt;
+  &lt;meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1"&gt;
+&lt;meta name="viewport" content="width=device-width, initial-scale=1.0"&gt;
+&lt;meta name="keywords" content="official dilbert website, dilbert comic strip, scott adams, Dilbert, Dogbert, Wally, The Pointy Haired Boss, Alice, Asok, Dogberts New Ruling Class, catbert, ratbert, mashups, animation, comics"&gt;
+&lt;meta name="description" content="The Official Dilbert Website featuring Scott Adams Dilbert strips, animation, mashups and more starring Dilbert, Dogbert, Wally, The Pointy Haired Boss, Alice, Asok, Dogberts New Ruling Class and more."&gt;
+&lt;meta name="twitter:creator" content="Dilbert_Daily"&gt;
+&lt;meta name="csrf-param" content="authenticity_token" /&gt;
+&lt;meta name="csrf-token" content="NF1anBWfSijL65KJBkpq2mbZcsNAmfmNUesXZdLZxtK95txBKHqyOi7Blf4tkleOB/IovmprG9B9SrfGq7G2Fg==" /&gt;
+    &lt;!-- Global Sharing --&gt;
+    &lt;!-- Facebook Open Graph Tags --&gt;
+    &lt;meta property="og:url" content="http://dilbert.com/"/&gt;
+    &lt;meta property="og:type" content="website"/&gt;
+    &lt;meta property="og:title" content="Welcome to Dilbert"/&gt;
+    &lt;!-- &lt;meta property="og:image" content=""/&gt; --&gt;
+    &lt;meta property="og:description" content="The Official Dilbert Website featuring Scott Adams Dilbert strips, animation, mashups and more starring Dilbert, Dogbert, Wally, The Pointy Haired Boss, Alice, Asok, Dogberts New Ruling Class and more."/&gt;
+    &lt;meta property="og:site_name" content="Dilbert"/&gt;
+    &lt;meta property="fb:app_id" content="163128967074041"/&gt;
+
+    &lt;!-- Dynamic Twitter Card Meta Tags --&gt;
+    &lt;meta name="twitter:url" content="http://dilbert.com/"&gt;
+    &lt;meta name="twitter:card" content="summary"&gt;
+    &lt;meta name="twitter:site" content="@Dilbert"&gt;
+    &lt;meta name="twitter:title" content="Welcome to Dilbert"&gt;
+    &lt;meta name="twitter:domain" content="https://dilbert.com/"&gt;
+    &lt;meta name="twitter:description" content="The Official Dilbert Website featuring Scott Adams Dilbert strips, animation, mashups and more starring Dilbert, Dogbert, Wally, The Pointy Haired Boss, Alice, Asok, Dogberts New Ruling Class and more."&gt;
+    &lt;!-- &lt;meta name="twitter:image:src" content=""&gt; --&gt;
+
+&lt;!-- Webmaster Tools Verification --&gt;
+&lt;meta name="google-site-verification" content="iMe_GbOppnxshIHn7KwTW8Eey9Lfzflvc9NrzGPoewI" /&gt;
+
+    &lt;link rel="canonical" href="https://www.dilbert.com/"&gt;
+
+  &lt;link rel="stylesheet" media="all" href="/assets/global-icons-f9068ad35b7b28d4fb587d113f115003b27c63ead4604513937269cbbe49216f.css" /&gt;
+  &lt;link rel="stylesheet" media="screen" href="/assets/packs/application-bb3b372ba6507e3db2c6a1ebcff62b0f.css" /&gt;
+
+  &lt;script src="/assets/cookies-b2884013a1ad9180342f0af884cc791f69592cbf0ad8431da28ce98cce758b26.js"&gt;&lt;/script&gt;
+
+  &lt;script async="" src="https://confiant-integrations.global.ssl.fastly.net/DN19JX_5rrJXKmPMrwRRdO8wyOY/gpt_and_prebid/config.js"&gt;&lt;/script&gt;
+
+&lt;!-- Prebid wrapper, intersection observer polyfill --&gt;
+&lt;script src="/assets/packs/ad-dependencies-2e7854e456812ad6a881.js"&gt;&lt;/script&gt;
+
+&lt;!-- Venatus Market Ad-Manager (dilbert.com) --&gt;
+&lt;script&gt;
+    (function(){document.write('&lt;div id="vmv3-ad-manager" style="display:none"&gt;&lt;/div&gt;');document.getElementById("vmv3-ad-manager").innerHTML='&lt;iframe id="vmv3-frm" src="javascript:\'&lt;html&gt;&lt;body&gt;&lt;/body&gt;&lt;/html&gt;\'" width="0" height="0" data-mode="scan" data-site-id="5b0433f746e0fb00017bc7d6"&gt;&lt;/iframe&gt;';var a=document.getElementById("vmv3-frm");a=a.contentWindow?a.contentWindow:a.contentDocument;a.document.open();a.document.write('&lt;script src="https://hb.vntsm.com/v3/live/ad-manager.min.js" type="text/javascript" async&gt;'+'&lt;/scr'+'ipt&gt;');a.document.close()})();
+&lt;/script&gt;
+&lt;!-- / Venatus Market Ad-Manager (dilbert.com) --&gt;
+
+&lt;!-- GPT --&gt;
+&lt;script async="async" src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"&gt;&lt;/script&gt;
+
+&lt;!-- Amazon --&gt;
+&lt;script&gt;
+    !function(a9,a,p,s,t,A,g){if(a[a9])return;function q(c,r){a[a9]._Q.push([c,r])}a[a9]={init:function(){q("i",arguments)},fetchBids:function(){q("f",arguments)},setDisplayBids:function(){},targetingKeys:function(){return[]},_Q:[]};A=p.createElement(s);A.async=!0;A.src=t;g=p.getElementsByTagName(s)[0];g.parentNode.insertBefore(A,g)}("apstag",window,document,"script","////c.amazon-adsystem.com/aax2/apstag.js");
+&lt;/script&gt;
+
+&lt;script&gt;
+    /***** Helper functions for ads *****/
+    var storeQueryString = function(){
+        var queryString = window.location.search.substring(1).split('&amp;');
+        for(var i=0; i&lt;queryString.length; i++){
+            var pair = queryString[i].split('=');
+            if(pair.length === 2){
+                amu_ads.query_string[pair[0]] = pair[1];
+            }
+        }
+    };
+
+    var findAds = function(className) {
+        var ads = document.getElementsByClassName(className);
+        ads = Array.prototype.slice.call(ads);
+        ads.map(function(element) {element.classList.remove(className);});
+
+        return ads
+    };
+
+    var getAdInfo = function (adElements) {
+        var adIds = adElements.map(getElementInfo);
+        adIds = adIds.filter(adSlotConfigExists).filter(servesAtBreakpoint);
+
+        return adIds;
+    };
+
+    var getAdSlot = function (slotInfo) {
+        return amu_ads.adSlots[slotInfo.id];
+    };
+
+    var adSlotConfigExists = function(slotInfo){
+        return typeof amu_ads.adSlotConfig[slotInfo.adType] !== 'undefined';
+    };
+
+    var servesAtBreakpoint = function(slotInfo){
+        var curBpt = amu_ads.adSlotConfig[slotInfo.adType].breakpoint;
+        return curBpt.sizes.length &gt; 0;
+    };
+
+    var getElementId = function(element){
+        return element.id;
+    };
+
+    var getElementAdType = function(element){
+        return element.getAttribute('data-ad-type');
+    };
+
+    var getElementInfo = function(element){
+        return {id: getElementId(element), adType: getElementAdType(element)};
+    };
+
+    var findBreakpoint = function(breakpointsArray){
+        var maxBpt, curBpt;
+        for (var i = 0; i &lt; breakpointsArray.length; i++) {
+            curBpt = breakpointsArray[i];
+            if (amu_ads.browserWidth &gt;= curBpt.minWidth &amp;&amp; amu_ads.browserHeight &gt;= curBpt.minHeight){
+                if(!maxBpt || (curBpt.minWidth &gt;= maxBpt.minWidth &amp;&amp; curBpt.minHeight &gt;= maxBpt.minHeight)){
+                    maxBpt = curBpt;
+                }
+            }
+        }
+        return maxBpt
+    };
+
+
+    var updatePageviewTargeting = function() {
+        var adPageview = getPageviewFromCookie();
+        Object.keys(amu_ads.adSlotConfig).forEach(function(key) {
+            amu_ads.adSlotConfig[key].targeting['pv'] = adPageview;
+        });
+    };
+
+    var adLazyLoaderInit = function (className) {
+        var adElements = Array.prototype.slice.call(document.getElementsByClassName(className));
+
+        adElements.forEach(function(element) {
+            element.classList.remove(className);
+            amu_ads.adLazyLoader.observe(element);
+        });
+    };
+
+    var adRefresherInit = function (className) {
+        if(!isEU){
+            var adElements = Array.prototype.slice.call(document.getElementsByClassName(className));
+
+            adElements.forEach(function(element) {
+                element.classList.remove(className);
+                amu_ads.adRefresher.observe(element);
+            });
+
+            if(typeof(amu_ads.adRefreshInterval) === 'undefined') {
+                amu_ads.adRefreshInterval = window.setInterval(handleAdRefreshInterval, amu_ads.adRefreshRate);
+            }
+        }
+    };
+
+    var handleAdLazyLoad = function (entries, observer) {
+        entries.forEach(function(entry) {
+            if(entry.isIntersecting){
+                // run auction on these elements
+                var adInfo = getAdInfo([entry.target]);
+                auctionInit(adInfo, false);
+                amu_ads.adLazyLoader.unobserve(entry.target);
+            }
+        });
+    };
+
+    var handleAdRefresh = function (entries, observer) {
+        var curAdId, curAdElement;
+        entries.forEach(function(entry) {
+            curAdElement = entry.target;
+            curAdId = curAdElement.id;
+            if(entry.intersectionRatio &gt;= 0.50) {
+                if(amu_ads.adSlots[curAdId]){
+                    amu_ads.inViewAds[curAdId] = curAdElement;
+                }
+            } else {
+                delete amu_ads.inViewAds[curAdId];
+            }
+        });
+    };
+
+    var handleAdRefreshInterval = function () {
+        if(amu_ads.adRefreshCount &lt; amu_ads.adRefreshMax) {
+            if(!document.hidden){
+
+                // Refresh in view ads
+                var adInfo = getAdInfo(Object.values(amu_ads.inViewAds));
+                auctionInit(adInfo, true);
+                // Update refresh count and clear inViewAds
+                amu_ads.adRefreshCount += 1;
+            }
+        } else {
+
+            // Stop refreshing
+            clearInterval(amu_ads.adRefreshInterval)
+        }
+    }
+
+&lt;/script&gt;
+&lt;script&gt;
+    // Global variable for advertising config
+    var amu_ads = amu_ads || {};
+
+    // Query string for changing ad slot path and ad channel
+    amu_ads.query_string = amu_ads.query_string || {};
+
+    // Browser and page info
+    amu_ads.browserWidth = "CSS1Compat" == window.document.compatMode ? window.document.documentElement.clientWidth : window.document.body.clientWidth;
+    amu_ads.browserHeight = "CSS1Compat" == window.document.compatMode ? window.document.documentElement.clientHeight : window.document.body.clientHeight;
+    amu_ads.pageDomain = window.location.hostname;
+    amu_ads.pagePath = window.location.pathname + location.search + location.hash;
+
+    // Ad channel (a or b)
+    //amu_ads.adChannel = '';
+
+    // Current page view number (based on cookie)
+    amu_ads.adPageview = setPageviewCookie();
+
+    // Ad unit path
+    amu_ads.adSlotPath = '/19196947/dilbert.com/home';
+
+
+    // Intersection observer for lazy loading ads
+    amu_ads.adLazyLoadOptions = {
+        rootMargin: amu_ads.browserWidth &gt;= 992 ? '200px' : '100px',
+        threshold: 0
+    };
+    amu_ads.adLazyLoader = new IntersectionObserver(handleAdLazyLoad, amu_ads.adLazyLoadOptions);
+
+
+    // Intersection observer for refreshing in view ads
+    amu_ads.adRefreshOptions = {
+        threshold: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+    };
+    amu_ads.adRefresher = new IntersectionObserver(handleAdRefresh, amu_ads.adRefreshOptions);
+    amu_ads.inViewAds = {};
+    amu_ads.adRefreshCount = 0;
+    amu_ads.adRefreshMax = 5;
+    amu_ads.adRefreshRate = 30000;
+
+    // Place to store DFP ad slots (needed in order to refresh ads)
+    amu_ads.adSlots = {};
+
+
+
+
+    /***** Bidder config *****/
+    // AppNexus tag config
+    amu_ads.appnexusTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869757,
+                keywords: {
+                    pos: ['top']
+                }
+            }
+        },
+
+
+        // 970x250, 970x90, 728x90, 320x50
+        'bot': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869751,
+                keywords: {
+                    pos: ['bot']
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        'right': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869756,
+                keywords: {
+                    pos: ['right']
+                }
+            }
+        },
+
+        // 300x250
+        'left': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869754,
+                keywords: {
+                    pos: ['left']
+                }
+            }
+        },
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'content': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869753,
+                keywords: {
+                    pos: ['content']
+                }
+            }
+        },
+
+        // 160x600, 300x600
+        'comments': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869752,
+                keywords: {
+                    pos: ['comments']
+                }
+            }
+        },
+
+        // 160x600
+        'anchored': {
+            bidder: 'appnexus',
+            params: {
+                placementId: 13869750,
+                keywords: {
+                    pos: ['anchored']
+                }
+            }
+        }
+    };
+
+
+    // Index tag config
+    amu_ads.ixTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        '970x250_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '294963',
+                size: [970,250]
+            }
+        },
+        '970x90_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '294963',
+                size: [970,90]
+            }
+        },
+        '728x90_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '294963',
+                size: [728,90]
+            }
+        },
+        '320x50_top': {
+            bidder: 'ix',
+            params: {
+                siteId: '294963',
+                size: [320,50]
+            }
+        },
+
+        // 970x250, 970x90, 728x90, 320x50
+        '970x250_bot': {
+            bidder: 'ix',
+            params: {
+                siteId: '294957',
+                size: [970, 250]
+            }
+        },
+        '970x90_bot': {
+            bidder: 'ix',
+            params: {
+                siteId: '294957',
+                size: [970, 90]
+            }
+        },
+        '728x90_bot': {
+            bidder: 'ix',
+            params: {
+                siteId: '294957',
+                size: [728, 90]
+            }
+        },
+        '320x50_bot': {
+            bidder: 'ix',
+            params: {
+                siteId: '294957',
+                size: [320, 50]
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        '300x250_left': {
+            bidder: 'ix',
+            params: {
+                siteId: '294960',
+                size: [300,250]
+            }
+        },
+
+        // 300x250
+        '300x250_right': {
+            bidder: 'ix',
+            params: {
+                siteId: '294962',
+                size: [300,250]
+            }
+        },
+
+
+        /***** Towers *****/
+        // 300x600, 300x250, 160x600
+        '300x600_content': {
+            bidder: 'ix',
+            params: {
+                siteId: '294959',
+                size: [300, 600]
+            }
+        },
+        '300x250_content': {
+            bidder: 'ix',
+            params: {
+                siteId: '294959',
+                size: [300,250]
+            }
+        },
+        '160x600_content': {
+            bidder: 'ix',
+            params: {
+                siteId: '294959',
+                size: [160,600]
+            }
+        },
+
+
+        // 300x600, 160x600
+        '300x600_comments': {
+            bidder: 'ix',
+            params: {
+                siteId: '294958',
+                size: [300, 600]
+            }
+        },
+        '160x600_comments': {
+            bidder: 'ix',
+            params: {
+                siteId: '294958',
+                size: [160,600]
+            }
+        },
+
+
+        // 160x600
+        '160x600_anchored': {
+            bidder: 'ix',
+            params: {
+                siteId: '294956',
+                size: [160, 600]
+            }
+        }
+    };
+
+    // OpenX tag config
+    amu_ads.openxTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'openx',
+            params: {
+                unit: 540251690,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'top'
+                }
+            }
+        },
+
+
+        // 970x250, 970x90, 728x90, 320x50
+        'bot': {
+            bidder: 'openx',
+            params: {
+                unit: 540251667,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'bot'
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        'left': {
+            bidder: 'openx',
+            params: {
+                unit: 540251683,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'left'
+                }
+            }
+        },
+
+        // 300x250
+        'right': {
+            bidder: 'openx',
+            params: {
+                unit: 540251687,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'right'
+                }
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 300x600, 300x250, 160x600
+        'content': {
+            bidder: 'openx',
+            params: {
+                unit: 540251676,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'content'
+                }
+            }
+        },
+
+        // 300x600, 160x600
+        'comments': {
+            bidder: 'openx',
+            params: {
+                unit: 540251672,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'comments'
+                }
+            }
+        },
+
+        // 160x600
+        'anchored': {
+            bidder: 'openx',
+            params: {
+                unit: 540251664,
+                delDomain: 'amu-d.openx.net',
+                customParams: {
+                    pos: 'anchored'
+                }
+            }
+        }
+    };
+
+
+    // PubMatic tag config
+    amu_ads.pubmaticTags = {
+
+        /***** Leaderboards and banners *****/
+        // 728x90, 970x90, 970x250, 320x50
+        'top': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887698'
+            }
+        },
+
+
+        // 728x90, 970x90, 970x250, 320x50
+        'bot': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887692'
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        'left': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887695'
+            }
+        },
+
+        // 300x250
+        'right': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887697'
+            }
+        },
+
+
+
+        /***** Towers *****/
+        // 160x600, 300x250, 300x600
+        'content': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887694'
+            }
+        },
+
+        // 160x600, 300x600
+        'comments': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887693'
+            }
+        },
+
+        // 160x600
+        'anchored': {
+            bidder: 'pubmatic',
+            params: {
+                publisherId: '157912',
+                adSlot: '1887691'
+            }
+        }
+    };
+
+
+    // Rubicon tag config
+    amu_ads.rubiconTags = {
+
+        /***** Leaderboards and banners *****/
+        // 970x250, 970x90, 728x90, 320x50
+        'top': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032618,
+                visitor: {
+                    'pos': ['top']
+                }
+            }
+        },
+
+
+        // 970x250, 970x90, 728x90, 320x50
+        'bot': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032600,
+                visitor: {
+                    'pos': ['bot']
+                }
+            }
+        },
+
+
+        /***** Rectangles *****/
+        // 300x250
+        'left': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032608,
+                visitor: {
+                    'pos': ['left']
+                }
+            }
+        },
+
+        // 300x250
+        'right': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032612,
+                visitor: {
+                    'pos': ['right']
+                }
+            }
+        },
+
+
+        /***** Towers *****/
+        // 300x250, 160x600, 300x600
+        'content': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032604,
+                visitor: {
+                    'pos': ['content']
+                }
+            }
+        },
+
+        // 160x600, 300x600
+        'comments': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032602,
+                visitor: {
+                    'pos': ['comments']
+                }
+            }
+        },
+
+        // 160x600
+        'anchored': {
+            bidder: 'rubicon',
+            params: {
+                accountId: 14256,
+                siteId: 210078,
+                zoneId: 1032598,
+                visitor: {
+                    'pos': ['anchored']
+                }
+            }
+        }
+    };
+
+
+    // Sovrn tag config
+    amu_ads.sovrnTags = {
+        /***** Leaderboards and banners *****/
+        '970x250_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580516'
+            }
+        },
+        '728x90_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580515'
+            }
+        },
+        '320x50_top': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580517'
+            }
+        },
+
+        '970x250_bot': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580505'
+            }
+        },
+        '728x90_bot': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580504'
+            }
+        },
+        '320x50_bot': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580506'
+            }
+        },
+
+
+        /***** Rectangles *****/
+        '300x250_left': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580512'
+            }
+        },
+
+        '300x250_right': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580514'
+            }
+        },
+
+
+        /***** Towers *****/
+        '300x250_content': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580510'
+            }
+        },
+        '160x600_content': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580509'
+            }
+        },
+        '300x600_content': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580511'
+            }
+        },
+
+
+        '160x600_comments': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580507'
+            }
+        },
+        '300x600_comments': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580508'
+            }
+        },
+
+
+        '160x600_anchored': {
+            bidder: 'sovrn',
+            params: {
+                tagid: '580503'
+            }
+        },
+
+    };
+
+
+
+    /***** Ad config *****/
+    // TODO: refactor/consolidate ad slot configs when layouts are more consistent
+    amu_ads.adSlotConfig = {};
+    amu_ads.adSlotConfig['leaderboard'] = {
+        name: 'leaderboard',
+        targeting: {
+            'pos': 'top',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 970,
+                minHeight: 850,
+                sizes: [[970, 250], [970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x250_top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['970x250_top'],
+                    amu_ads.sovrnTags['728x90_top']
+                ]
+            },
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['970x90_top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90], [320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['728x90_top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['728x90_top'],
+                    amu_ads.sovrnTags['320x50_top']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['top'],
+                    amu_ads.ixTags['320x50_top'],
+                    amu_ads.openxTags['top'],
+                    amu_ads.pubmaticTags['top'],
+                    amu_ads.rubiconTags['top'],
+                    amu_ads.sovrnTags['320x50_top']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['leaderboard'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['leaderboard'].breakpoints);
+
+
+    amu_ads.adSlotConfig['banner'] = {
+        name: 'banner',
+        targeting: {
+            'pos': 'bot',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 970,
+                minHeight: 0,
+                sizes: [[970, 250], [970, 90], [728, 90]],
+                bids: [
+                    amu_ads.appnexusTags['bot'],
+                    amu_ads.ixTags['970x250_bot'],
+                    amu_ads.ixTags['970x90_bot'],
+                    amu_ads.ixTags['728x90_bot'],
+                    amu_ads.openxTags['bot'],
+                    amu_ads.pubmaticTags['bot'],
+                    amu_ads.rubiconTags['bot'],
+                    amu_ads.sovrnTags['970x250_bot'],
+                    amu_ads.sovrnTags['728x90_bot']
+                ]
+            },
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90], [320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['bot'],
+                    amu_ads.ixTags['728x90_bot'],
+                    amu_ads.ixTags['320x50_bot'],
+                    amu_ads.openxTags['bot'],
+                    amu_ads.pubmaticTags['bot'],
+                    amu_ads.rubiconTags['bot'],
+                    amu_ads.sovrnTags['728x90_bot'],
+                    amu_ads.sovrnTags['320x50_bot']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[320, 50]],
+                bids: [
+                    amu_ads.appnexusTags['bot'],
+                    amu_ads.ixTags['320x50_bot'],
+                    amu_ads.openxTags['bot'],
+                    amu_ads.pubmaticTags['bot'],
+                    amu_ads.rubiconTags['bot'],
+                    amu_ads.sovrnTags['320x50_bot']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['banner'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['banner'].breakpoints);
+
+
+    amu_ads.adSlotConfig['rectangle'] = {
+        name: 'rectangle',
+        targeting: {
+            'pos': 'left',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['left'],
+                    amu_ads.ixTags['300x250_left'],
+                    amu_ads.openxTags['left'],
+                    amu_ads.pubmaticTags['left'],
+                    amu_ads.rubiconTags['left'],
+                    amu_ads.sovrnTags['300x250_left']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['rectangle'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['rectangle'].breakpoints);
+
+
+    amu_ads.adSlotConfig['rectangle_right'] = {
+        name: 'rectangle_right',
+        targeting: {
+            'pos': 'right',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['right'],
+                    amu_ads.ixTags['300x250_right'],
+                    amu_ads.openxTags['right'],
+                    amu_ads.pubmaticTags['right'],
+                    amu_ads.rubiconTags['right'],
+                    amu_ads.sovrnTags['300x250_right']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['rectangle_right'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['rectangle_right'].breakpoints);
+
+
+    amu_ads.adSlotConfig['tower_content'] = {
+        name: 'tower_content',
+        targeting: {
+            'pos': 'content',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 600], [160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['content'],
+                    amu_ads.ixTags['300x600_content'],
+                    amu_ads.ixTags['160x600_content'],
+                    amu_ads.openxTags['content'],
+                    amu_ads.pubmaticTags['content'],
+                    amu_ads.rubiconTags['content'],
+                    amu_ads.sovrnTags['300x600_content'],
+                    amu_ads.sovrnTags['160x600_content']
+                ]
+            },
+            {
+                minWidth: 768,
+                minHeight: 0,
+                sizes: [[160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['content'],
+                    amu_ads.ixTags['160x600_content'],
+                    amu_ads.openxTags['content'],
+                    amu_ads.pubmaticTags['content'],
+                    amu_ads.rubiconTags['content'],
+                    amu_ads.sovrnTags['160x600_content']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[300, 250]],
+                bids: [
+                    amu_ads.appnexusTags['content'],
+                    amu_ads.ixTags['300x250_content'],
+                    amu_ads.openxTags['content'],
+                    amu_ads.pubmaticTags['content'],
+                    amu_ads.rubiconTags['content'],
+                    amu_ads.sovrnTags['300x250_content']
+                ]
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_content'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_content'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tower_comments'] = {
+        name: 'tower_comments',
+        targeting: {
+            'pos': 'comments',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 992,
+                minHeight: 0,
+                sizes: [[300, 600], [160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['comments'],
+                    amu_ads.ixTags['300x600_comments'],
+                    amu_ads.ixTags['160x600_comments'],
+                    amu_ads.openxTags['comments'],
+                    amu_ads.pubmaticTags['comments'],
+                    amu_ads.rubiconTags['comments'],
+                    amu_ads.sovrnTags['300x600_comments'],
+                    amu_ads.sovrnTags['160x600_comments']
+                ]
+            },
+            {
+                minWidth: 768,
+                minHeight: 0,
+                sizes: [[160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['comments'],
+                    amu_ads.ixTags['160x600_comments'],
+                    amu_ads.openxTags['comments'],
+                    amu_ads.pubmaticTags['comments'],
+                    amu_ads.rubiconTags['comments'],
+                    amu_ads.sovrnTags['160x600_comments']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_comments'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_comments'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['tower_anchored'] = {
+        name: 'tower_anchored',
+        targeting: {
+            'pos': 'anchored',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 1400,
+                minHeight: 620,
+                sizes: [[160, 600]],
+                bids: [
+                    amu_ads.appnexusTags['anchored'],
+                    amu_ads.ixTags['160x600_anchored'],
+                    amu_ads.openxTags['anchored'],
+                    amu_ads.pubmaticTags['anchored'],
+                    amu_ads.rubiconTags['anchored'],
+                    amu_ads.sovrnTags['160x600_anchored']
+                ]
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tower_anchored'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tower_anchored'].breakpoints);
+
+
+    amu_ads.adSlotConfig['tynt'] = {
+        name: 'tynt',
+        targeting: {
+            'pos': 'locked',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 728,
+                minHeight: 0,
+                sizes: [[728, 90]],
+                bids: []
+            },
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['tynt'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['tynt'].breakpoints);
+
+
+
+    amu_ads.adSlotConfig['venatus'] = {
+        name: 'ventatus',
+        targeting: {
+            'pos': 'venatus',
+            'pv': amu_ads.adPageview
+        },
+        breakpoints: [
+            {
+                minWidth: 0,
+                minHeight: 0,
+                sizes: [[1, 1]],
+                bids: []
+            }
+        ]
+    };
+    amu_ads.adSlotConfig['venatus'].breakpoint = findBreakpoint(amu_ads.adSlotConfig['venatus'].breakpoints);
+&lt;/script&gt;
+
+&lt;script&gt;
+    // Venatus
+    var isEU = false;
+    window.VM_API = window.VM_API || [];
+
+    var PREBID_TIMEOUT = 1500;
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
+
+    var customPriceBuckets = {
+        'buckets': [
+            // 1 cent increments up to 50 cents
+            {
+                'min': 0.00,
+                'max': 0.50,
+                'increment': 0.01
+            },
+            // 5 cent increments up to 5 dollars
+            {
+                'min': 0.50,
+                'max': 5.00,
+                'increment': 0.05
+            },
+            // 10 cent increments up to 10 dollars
+            {
+                'min': 5.00,
+                'max': 10.00,
+                'increment': 0.10
+            },
+            // 50 cent increments up to 20 dollars
+            {
+                'min': 10.00,
+                'max': 20.00,
+                'increment': 0.50
+            },
+            // 1 dollar increments up to 50 dollars
+            {
+                'min': 20.00,
+                'max': 50.00,
+                'increment': 1.00
+            }
+        ]
+    };
+
+    pbjs.que.push(function() {
+        pbjs.setConfig({
+            enableSendAllBids: true,
+            priceGranularity: customPriceBuckets,
+            userSync: {
+                iframeEnabled: true,
+                filterSettings: {
+                    iframe: {
+                        bidders: '*',      // '*' represents all bidders
+                        filter: 'include'
+                    }
+                }
+            }
+        });
+    });
+
+
+    // Confiant
+    // Wrapper for AMUniversal (GoComics), generated on 2018-10-26T16:40:06-04:00, version 2018.04.02
+    pbjs.que.push(function() {
+
+        // keep a reference to original renderAd function
+        var w = window;
+        w._clrm = w._clrm || {};
+        w._clrm.renderAd = w._clrm.renderAd || pbjs.renderAd;
+        var config = w._clrm.prebid || {
+            /* Enables sandboxing on a device group
+                 All:1 , Desktop:2, Mobile: 3, iOS: 4, Android: 5, Off: 0
+             */
+            sandbox: 0
+        };
+
+        var isGoogleFrame = function (c) {
+            return c.tagName === 'IFRAME' &amp;&amp; c.id &amp;&amp; c.id.indexOf('google_ads_iframe_') &gt; -1;
+        };
+
+        var shouldSandbox = function () {
+            var uaToRegexMap = {
+                    "mobile": /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/i,
+                    "ios": /(.+)(iPhone|iPad|iPod)(.+)OS[\s|\_](\d)\_?(\d)?[\_]?(\d)?.+/i,
+                    "android": /Android/i
+                },
+                sbStr = "" +config.sandbox;
+            if (sbStr === "1") {
+                // all environments
+                return true;
+            } else if (sbStr === "2") {
+                // desktop
+                return !navigator.userAgent.match(uaToRegexMap["mobile"]);
+            } else if (sbStr === "3") {
+                // mobile
+                return navigator.userAgent.match(uaToRegexMap["mobile"]);
+            } else if (sbStr === "4") {
+                // ios only
+                return navigator.userAgent.match(uaToRegexMap["ios"]);
+            } else if (sbStr === "5") {
+                // android
+                return navigator.userAgent.match(uaToRegexMap["android"]);
+            } else {
+                return false;
+            }
+        };
+
+        Node.prototype.appendChild = (function (original) {
+            return function (child) {
+                if (isGoogleFrame(child) &amp;&amp; shouldSandbox() &amp;&amp; !child.getAttribute('sandbox')) {
+                    child.setAttribute('sandbox', 'allow-forms allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation');
+                    child.setAttribute('data-forced-sandbox', true);
+                }
+                return original.call(this, child);
+            };
+        }(Node.prototype.appendChild));
+
+
+        // override renderAd
+        pbjs.renderAd = function(doc, id) {
+            if (doc &amp;&amp; id) {
+                try {
+
+                    // get pbjs bids
+                    var bids = [],
+                        bidResponses = pbjs.getBidResponses(),
+                        highestBids = pbjs.getHighestCpmBids();
+                    for (var slot in bidResponses) {
+                        bids = bids.concat(bidResponses[slot].bids);
+                    }
+                    bids = bids.concat(highestBids);
+
+                    // lookup ad by ad Id (avoid ES6 array functions)
+                    var bid, i;
+                    for (i=0; i&lt;bids.length; i++) {
+                        if (bids[i].adId === id) {
+                            bid = bids[i];
+                            break;
+                        }
+                    }
+
+                    // Optional: list of bidders that don't need wrapping, array of strings, e.g.: ["bidder1", "bidder2"]
+                    var confiantExcludeBidders = [];
+
+                    // check bidder exclusion (avoid ES6 array functions)
+                    var excludeBidder = false;
+                    for (i=0; i&lt;confiantExcludeBidders.length; i++) {
+                        if (bid.bidder === confiantExcludeBidders[i]) {
+                            excludeBidder = true;
+                            break;
+                        }
+                    }
+
+                    if (bid &amp;&amp; bid.ad &amp;&amp; !excludeBidder) {
+                        // Neutralize document
+                        var docwrite = doc.write;
+                        var docclose = doc.close;
+                        doc.write = doc.close = function() {};
+                        // call renderAd with our neutralized doc.write
+                        window._clrm.renderAd(doc, id);
+                        // Restore document
+                        delete doc.write;
+                        delete doc.close;
+
+                        var callback = function(blockingType, blockingId, isBlocked, wrapperId, tagId, impressionData) {
+                            console.log("w00t one more bad ad nixed.", arguments);
+                        };
+
+                        return;
+                    }
+                } catch (e) {
+                    console.log(e);
+                }
+            }
+
+            // if bid.ad is not defined or if any error occurs, call renderAd to serve the creative
+            window._clrm.renderAd(doc, id);
+        };
+
+    });
+
+
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    googletag.cmd.push(function() {
+        googletag.pubads().disableInitialLoad();
+
+        // Event listener for when slot renders
+        //googletag.pubads().addEventListener('slotRenderEnded', function(event) {
+            // Element Id of the slot
+            //var slotId = event.slot.getSlotElementId();
+        //});
+    });
+
+    apstag.init({
+        pubID: 'af9aec0d-17e4-4619-825c-371fa3483a58',
+        adServer: 'googletag'
+    });
+&lt;/script&gt;
+
+&lt;script&gt;
+    function startAuction(bidTimeout, adInfo, adSlots, refresh) {
+        // Define bidders
+        var bidders = ['a9', 'prebid'];
+
+        // create a requestManager to keep track of bidder state to determine when to send ad server
+        // request and what apstagSlots to request from the ad server
+        var requestManager = {
+            adServerRequestSent: false
+        };
+        // add the bidders to the request manager:
+        bidders.forEach(function(bidder) {
+            requestManager[bidder] = false;
+        });
+
+        // return true if all bidders have returned
+        function allBiddersDone () {
+            return bidders.filter(function(bidder) {return requestManager[bidder];}).length === bidders.length;
+        }
+
+        // handler for header bidder responses
+        function bidderDone(bidder) {
+            if (requestManager.adServerRequestSent === false) {
+                // flip the boolean associated with the bidder in the request manager
+                requestManager[bidder] = true;
+
+                // if all bidders are back, send the request to the ad server
+                if (allBiddersDone()) {
+                    sendAdserverRequest(adInfo, adSlots, refresh);
+                }
+            }
+        }
+
+        // actually get ads from DFP
+        function sendAdserverRequest(adInfo, adSlots, refresh) {
+            if (requestManager.adServerRequestSent === false) {
+                requestManager.adServerRequestSent = true;
+                pbjs.que.push(function() {
+                    googletag.cmd.push(function() {
+                        if(!refresh){
+                            // 5. Display Ads
+                            displayAds(adInfo);
+                        }
+
+                        // 6. Refresh bids
+                        refreshAds(adSlots);
+                    });
+                });
+            }
+        }
+
+        function requestBids(adInfo, adSlots) {
+            // Fetch Amazon bids
+            amzn_fetchBids(adInfo, adSlots);
+
+            // Fetch Prebid bids
+            prebid_fetchBids(adInfo, adSlots);
+
+        }
+
+        /***** Amazon helper functions *****/
+        function amzn_buildSlotsArray(adInfo) {
+            var slotsArray = [];
+            var i, curAdId, curAdType;
+            for (i = 0; i &lt; adInfo.length; i++) {
+                curAdId = adInfo[i].id;
+                curAdType = adInfo[i].adType;
+                slotsArray.push({
+                    slotID: curAdId,
+                    sizes: amu_ads.adSlotConfig[curAdType].breakpoint.sizes
+                });
+            }
+            return slotsArray;
+
+        }
+
+        function amzn_fetchBids(adInfo, adSlots) {
+            // Fetch Amazon bids for slots on page
+            apstag.fetchBids(
+                {
+                    slots: amzn_buildSlotsArray(adInfo),
+                    timeout: 1000
+                },
+                function (bids) {
+                    pbjs.que.push(function () {
+                        googletag.cmd.push(function () {
+                            // Set Amazon bid key-values pairs
+                            try {
+                                apstag.setDisplayBids();
+                            } catch (e) {
+                                //do nothing
+                            }
+                        });
+                        bidderDone('a9', adInfo, adSlots);
+                    });
+                }
+            );
+        }
+
+        /* Prebid helper functions */
+        var prebid_fetchBids = function(adInfo, adSlots) {
+            var curAdIds = adInfo.map(function(e){return e.id;});
+            pbjs.que.push(function() {
+                pbjs.requestBids({
+                    timeout: PREBID_TIMEOUT,
+                    adUnitCodes: curAdIds,
+                    bidsBackHandler: function() {
+                        googletag.cmd.push(function() {
+                            pbjs.setTargetingForGPTAsync(curAdIds);
+                        });
+                        bidderDone('prebid', adInfo, adSlots);
+                    }
+                });
+            });
+        };
+
+        // ask bidders for their bids
+        requestBids(adInfo, adSlots);
+        // set timeout to send request to call sendAdserverRequest() after timeout
+        // it all bidders haven't returned before then
+        window.setTimeout(function() {
+            sendAdserverRequest(adInfo, adSlots);
+        }, bidTimeout);
+    }
+&lt;/script&gt;
+
+&lt;script&gt;
+    var buildAdUnits = function(adInfo) {
+        var adUnits = [];
+        var curUnit, curAdId, curAdType;
+        for(var i = 0; i &lt; adInfo.length; i++) {
+            curAdId = adInfo[i].id;
+            curAdType = adInfo[i].adType;
+            curUnit = {
+                code: curAdId,
+                mediaTypes: {
+                    banner: {
+                        sizes: amu_ads.adSlotConfig[curAdType].breakpoint.sizes
+                    }
+                },
+                bids: amu_ads.adSlotConfig[curAdType].breakpoint.bids
+            };
+            adUnits.push(curUnit);
+        }
+        return adUnits
+    };
+
+    var defineAds = function(adInfo) {
+        var slots = [];
+        var i, curSlot, curAdId, curAdType;
+        for (i = 0; i &lt; adInfo.length; i++) {
+            curAdId = adInfo[i].id;
+            curAdType = adInfo[i].adType;
+            // Define slot
+            curSlot = googletag.defineSlot(amu_ads.adSlotPath, amu_ads.adSlotConfig[curAdType].breakpoint.sizes, curAdId).addService(googletag.pubads());
+
+            // Set slot level targeting
+            for (key in amu_ads.adSlotConfig[curAdType].targeting) {
+                curSlot.setTargeting(key, amu_ads.adSlotConfig[curAdType].targeting[key]);
+            }
+
+            slots.push(curSlot);
+
+            // Store slot for later use (refreshing ads, etc)
+            amu_ads.adSlots[curAdId] = curSlot;
+
+        }
+        return slots;
+    };
+
+    var displayAds = function(adInfo) {
+        var curAdId;
+        if(adInfo.length === 0) {
+            googletag.display();
+        } else {
+            for(var i = 0; i &lt; adInfo.length; i++) {
+                curAdId = adInfo[i].id;
+                googletag.display(curAdId);
+            }
+        }
+    };
+
+    var refreshAds = function(adSlots) {
+        for(var i = 0; i &lt; adSlots.length; i++) {
+            adSlots[i].setTargeting('pv', getPageviewFromCookie());
+        }
+
+        if(adSlots.length === 0) {
+            googletag.pubads().refresh();
+        } else {
+            googletag.pubads().refresh(adSlots);
+        }
+    };
+
+    var auctionInit = function(adInfo, refresh) {
+        if(adInfo.length &gt; 0){
+            if(isEU) {
+                googletag.cmd.push(function() {
+                    // Define ads
+                    var adSlots = defineAds(adInfo);
+
+                    // Enable services for GPT
+                    googletag.enableServices();
+
+                    // Display Ads
+                    displayAds(adInfo);
+
+                    // Refresh bids
+                    refreshAds(adSlots);
+                });
+            } else {
+                pbjs.que.push(function() {
+                    googletag.cmd.push(function() {
+                        if(!refresh) {
+                            // Build ad units and add them to Prebid
+                            var adUnits = buildAdUnits(adInfo);
+                            pbjs.addAdUnits(adUnits);
+
+                            // Define ads
+                            var adSlots = defineAds(adInfo);
+
+                            // Enable services for GPT
+                            googletag.enableServices();
+                        } else {
+                            // Get existing ad slots
+                            var adSlots = adInfo.map(getAdSlot);
+                        }
+                        // Start header-bidding auction
+                        startAuction(1500, adInfo, adSlots, refresh);
+                    });
+                });
+            }
+        }
+    };
+
+    // Venatus
+    window.VM_API.push({
+        call: "is-consent-required",
+        onResult: function(res) {
+            //res = true in EU
+            //res = false outside EU
+            isEU = res;
+            if (document.readyState === "loading") {
+                document.addEventListener("DOMContentLoaded", function(event) {
+                    // Find ads
+                    var adElements = findAds('js-ad');
+
+                    // Get ad info
+                    var adInfo = getAdInfo(adElements);
+                    auctionInit(adInfo, false);
+
+                    //Lazy load ads
+                    adLazyLoaderInit('js-ad-lazy-load');
+
+                    // Refresh in view ads
+                    adRefresherInit('js-ad-refresh');
+                });
+            } else {
+                // Find ads
+                var adElements = findAds('js-ad');
+
+                // Get ad info
+                var adInfo = getAdInfo(adElements);
+
+                auctionInit(adInfo, false);
+
+                //Lazy load ads
+                adLazyLoaderInit('js-ad-lazy-load');
+
+                // Refresh ads in view
+                adRefresherInit('js-ad-refresh');
+            }
+        }
+    });
+
+&lt;/script&gt;
+
+
+&lt;!-- Sharethrough --&gt;
+&lt;script type="text/javascript" src="https://native.sharethrough.com/assets/sfp.js"&gt;&lt;/script&gt;
+
+  &lt;script src="/assets/application-313b7a6fafe9cac925824ccb4509a56f70853f175eb8361a4bda4d8669075081.js"&gt;&lt;/script&gt;
+  &lt;script src="/assets/packs/vendor-75451604b7930645e148.js"&gt;&lt;/script&gt;
+  &lt;script src="/assets/packs/application-60c6f4bcb5718ee7f628.js"&gt;&lt;/script&gt;
+
+  &lt;!-- Content Experiment JavaScript API client --&gt;
+&lt;script src="//www.google-analytics.com/cx/api.js?experiment=of4I6R6WTsCKu6PXpqZ_7w"&gt;&lt;/script&gt;
+
+&lt;script&gt;
+  // Ask Google Analytics which variation to show the visitor.
+  var chosenVariation = cxApi.chooseVariation();
+
+&lt;/script&gt;
+
+  &lt;script&gt;
+// Wait for the DOM to load, then execute the view for the chosen variation.
+
+uuExperimentInit = function(event) {
+
+  //if(chosenVariation === 0) {
+    // Variation 1 
+    // console.log('Experiment Version: Variation (B)');
+    // console.log('Google Response: ' + chosenVariation);
+    // $('.js-exp-original').addClass('hidden');
+    // $('.js-exp-variation').removeClass('hidden');
+  //} else {
+    // Original Variation
+    //console.log('Experiment Version: Original (A)');
+    //console.log('Google Response: ' + chosenVariation);
+    //$('.js-exp-variation').addClass('hidden');
+    //$('.js-exp-original').removeClass('hidden');
+  //}
+}
+
+$(document).ready(function() {
+  uuExperimentInit();
+});
+&lt;/script&gt;
+
+  &lt;link rel="alternate" type="application/atom+xml" title="ATOM" href="/feed" /&gt;
+  &lt;link rel="alternate" type="application/rss+xml" title="RSS" href="/feed.rss" /&gt;
+
+  &lt;!-- Begin comScore Tag --&gt;
+&lt;script&gt;
+    var _comscore = _comscore || [];
+    _comscore.push({ c1: "2", c2: "20519258" });
+    (function() {
+        var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+        s.src = (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js";
+        el.parentNode.insertBefore(s, el);
+    })();
+&lt;/script&gt;
+&lt;noscript&gt;
+  &lt;img src="http://b.scorecardresearch.com/p?c1=2&amp;c2=20519258&amp;cv=2.0&amp;cj=1" alt="" /&gt;
+&lt;/noscript&gt;
+&lt;!-- End comScore Tag --&gt;
+
+  &lt;script type="text/javascript"&gt;
+//Set markup and styling here
+window.cookieconsent_options = {
+  learnMore: 'More info',
+  link: '//andrewsmcmeel.com/privacy-policy',
+  //If you wish to use your own CSS instead, specify the URL of your CSS file. e.g. styles/my_custom_theme.css.
+  //This can be a relative or absolute URL.
+  //To stop Cookie Consent from loading CSS at all, specify false
+  //IE8 Styles need to be duplicated in app specific css overrides /assets/stylesheets/ie/ie8.css
+  theme: false,
+  markup: [
+    '&lt;div id="js-cookie-consent"&gt;',
+    '&lt;style type="text/css"&gt;.cc_banner-wrapper {height: 70px; } .cc_container {z-index:9001; position:fixed; width:100%; left:0; top:0; right:0; overflow:hidden; background-color:#666; } .cookie-choices-info {margin:0; padding:0; text-align:center; color:#fff; line-height:140%; padding:15px 0; font-family:roboto,Arial } .cookie-choices-info .cookie-choices-text {display:inline-block; vertical-align:middle; font-size:16px; margin:10px; color:#fefefe; max-width:800px; text-align:center } .cookie-choices-info .cookie-choices-buttons {display:inline-block; vertical-align:middle; white-space:nowrap; margin:10px } .cookie-choices-info .cookie-choices-button:hover {color:#fff; background-color:#000 } .cookie-choices-info .cookie-choices-button {background:#444; font-weight:700; text-transform:UPPERCASE; white-space:nowrap; color:#eee; margin-left:8px; padding:10px; border-radius:3px; text-decoration:none } @media screen and (max-width: 851px) {.cc_banner-wrapper {height:110px } } @media screen and (max-width: 588px) {.cc_banner-wrapper {height:140px } } @media screen and (max-width: 327px) {.cc_banner-wrapper {height:160px } } @media print {.cc_banner-wrapper,.cc_container {display:none } }&lt;/style&gt;',
+    '&lt;div class="cc_banner-wrapper {{containerClasses}}"&gt;',
+    '&lt;div class="cc_banner cc_container cc_container--open"&gt;',
+    '&lt;div class="cookie-choices-info"&gt;&lt;div class="cookie-choices-inner"&gt;&lt;span class="cookie-choices-text"&gt;{{options.message}}&lt;/span&gt;&lt;span class="cookie-choices-buttons"&gt; &lt;a data-cc-if="options.link" class="cookie-choices-button" target="_blank" href="//www.andrewsmcmeel.com/privacy-policy"&gt;{{options.learnMore}}&lt;/a&gt; &lt;a id="cookieChoiceDismiss" href="#null" data-cc-event="click:dismiss"  class="cookie-choices-button"&gt;{{options.dismiss}}&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;&lt;/div&gt;',
+    '&lt;/div&gt;',
+    '&lt;/div&gt;',
+    '&lt;/div&gt;'
+  ],
+  cookieName: 'dilbert_cookieconsent_dismissed',
+  readystate: 'interactive'
+};
+&lt;/script&gt;
+&lt;/head&gt;
+
+&lt;body class="layout-anchored" role="document"&gt;
+
+    &lt;!-- Google Universal Analytics Start --&gt;
+&lt;script&gt;
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  // UU Tracking Object
+  ga('create', "UA-273330-47", 'auto', {'name': 'trackerUU47'});
+  ga('trackerUU47.require', 'displayfeatures');
+  ga('trackerUU47.require', 'linkid');
+  ga('trackerUU47.require', 'outboundLinkTracker', {
+      shouldTrackOutboundLink: function(link) {
+          // Checks that the link's hostname does not contain "example.com".
+          return link.hostname.indexOf('dilbert.com') &lt; 0;
+      }
+  });
+  ga('trackerUU47.set', 'dimension1', "Dilbert Website");
+  ga('trackerUU47.set', 'dimension2', "Dilbert");
+  //ga(
+  //ga('.set'), 'dimension3', Subscribed to Newsletter);
+  //ga('.set'), 'dimension4', User - Blocking Ads);
+  //ga('.set'), 'dimension5', Pageview - Blocking Ads);
+  //ga('.set'), 'dimension6', Pageview - Ad Count);
+
+  ga('trackerUU47.send', 'pageview');
+
+  // Analytics Time Tracking
+  var trackTimeSpent = function(time) {
+    ga('trackerUU47.send', 'event', "Comics", "Dilbert", "");
+    //completionTime);
+  };
+
+  // Analytics Virtual Pageview Hit - Asynchronous View Change 
+  var trackItemsLoad = function(items) {
+    var currentPage = Math.round(parseInt(items - 1,10) / 3);
+    ga('trackerUU47.set', { "page": '' + currentPage, "title": "Dilbert - Page " + currentPage});
+    ga('trackerUU47.send', 'pageview');
+  };
+  
+  //Analytics Event Tracking - Sharing
+  var trackSharingToggle = function() {
+    ga('trackerUU47.send', 'event', 'social', 'Share - Activated Toggle');
+  };
+
+    var trackSharingToggle = function() {
+    ga('trackerUU47.send', 'event', 'social', 'Share - Activated Toggle');
+  };
+
+  // no longer used
+  var trackSharingCopiedLink = function() {
+    ga('trackerUU47.send', 'event', 'social', 'Share - Shared via Copied Link');
+  };
+
+  var trackSharingNetwork = function(network) {
+    ga('trackerUU47.send', 'event', 'social', 'Share - Shared via ' + network);
+  };
+  
+  var trackRating = function() {
+    ga('trackerUU47.send', 'event', 'social', 'UX - Comic Rated');
+  };
+  
+  var trackUXGeneric = function(trackingLabel) {
+    ga('trackerUU47.send', 'event', 'social', 'UX - ' + trackingLabel);
+  };
+
+  var trackFollow = function(trackingLabel) {
+    ga('trackerUU47.send', 'event', 'social', 'Follow - ' + trackingLabel);
+  };
+
+
+&lt;/script&gt;
+&lt;!-- Google Universal Analytics End --&gt;
+
+&lt;!-- Beginning of AMU Marketing Silverpop Tracking --&gt;
+&lt;meta name="com.silverpop.brandeddomains" content="www.pages02.net,ampkids.com,amureprints.com,andrewsmcmeel.com,calvinandhobbes.com,dilbert.com,epicbignate.com,gocomics.com,puzzlesociety.com,uexpress.com,wonderword.universaluclick.com" /&gt;
+&lt;!-- End of AMU Marketing Silverpop Tracking --&gt;
+
+    &lt;div class="container-fluid"&gt;
+        &lt;!-- HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START HEADER START --&gt;
+&lt;div class="site-bg-bar"&gt;&lt;/div&gt;
+&lt;div class="container-header"&gt;
+  &lt;header class="site-header" role="banner"&gt;
+    &lt;div class="visible-xs-block site-mobile-header"&gt;
+      &lt;a class="btn btn-link site-header-mobile-link pull-left js-toggle-link" href="" data-target=".site-header-nav"&gt;&lt;i class="fa fa-bars fa-lg" aria-hidden="true"&gt;&lt;/i&gt;&lt;i class="fa fa-times fa-lg" aria-hidden="true"&gt;&lt;/i&gt; &lt;span class="sr-only"&gt;Menu&lt;/span&gt;&lt;/a&gt;
+      &lt;a href="" class="btn btn-link pull-right site-header-mobile-link js-toggle-link" data-target=".site-header-mobile-search"&gt;&lt;i class="fa fa-search fa-lg" aria-hidden="true"&gt;&lt;/i&gt;&lt;i class="fa fa-times fa-lg" aria-hidden="true"&gt;&lt;/i&gt; &lt;span class="sr-only"&gt;Search&lt;/span&gt;&lt;/a&gt;
+    &lt;/div&gt;
+    &lt;div class="site-header-branding"&gt;
+      &lt;span class="logo-container"&gt;&lt;a class="logo" title="Dilbert Logo" href="https://dilbert.com/"&gt;&lt;img src="/assets/dilbert-logo-b9a1fc1f44d5b72cb9eadcb5fa150087243ee83350dc600285879087887de0f0.png" alt="Dilbert logo" width="144" height="127" /&gt;&lt;/a&gt;&lt;/span&gt;
+      &lt;span class="hidden-xs"&gt;&lt;img class="characters-top" alt="" src="/assets/dilbert_character_top-8c372237e95037529b2eb865829ee93214d7575811f4a197b2ebe43966cda5fa.png" width="169" height="107" /&gt;&lt;/span&gt;
+    &lt;/div&gt;
+    &lt;!-- /.site-header-branding --&gt;
+    &lt;div class="site-header-nav hidden-xs"&gt;
+      &lt;nav role="navigation"&gt;
+        &lt;ul class="nav-main" role="menubar"&gt;
+          &lt;li role="menuitem" class="nav-main-item active"&gt;
+            &lt;a class="nav-main-link" href="https://dilbert.com/"&gt;Comics&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" class="nav-main-item "&gt;
+            &lt;a class="nav-main-link" href="http://blog.dilbert.com?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-engagement&amp;amp;utm_content=navigation"&gt;Blog&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" tabindex="-1" class="nav-main-item"&gt;&lt;a class="nav-main-link dropdown-toggle js-follow-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" href="#"&gt;Follow&lt;/a&gt;
+            &lt;ul role="menubar" class="dropdown-menu nav-main-dropdown"&gt;
+              &lt;li role="menuitem" class="nav-sub-item"&gt;&lt;a class="js-follow-facebook" href="https://www.facebook.com/dilbert?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-social&amp;amp;utm_content=navigation" target="_blank"&gt;&lt;i class="fa fa-fw fa-facebook"&gt;&lt;/i&gt; Facebook&lt;/a&gt;&lt;/li&gt;
+              &lt;li role="menuitem" class="nav-sub-item"&gt;&lt;a class="js-follow-twitter" href="https://twitter.com/Dilbert_Daily?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-social&amp;amp;utm_content=navigation" target="_blank"&gt;&lt;i class="fa fa-fw fa-twitter"&gt;&lt;/i&gt; Twitter&lt;/a&gt;&lt;/li&gt;
+              &lt;li role="menuitem" class="nav-sub-item"&gt;
+                &lt;a class="js-follow-comic-feed link-blended" target="_blank" href="http://feed.dilbert.com/dilbert/daily_strip"&gt;&lt;i class='fa fa-fw fa-rss'&gt;&lt;/i&gt; Comics&lt;/a&gt;&lt;/li&gt;
+              &lt;li role="menuitem" class="nav-sub-item"&gt;
+                &lt;a class="js-follow-blog-feed link-blended" href="http://feed.dilbert.com/dilbert/blog"&gt;&lt;i class='fa fa-fw fa-rss'&gt;&lt;/i&gt; Blog&lt;/a&gt;&lt;/li&gt;
+            &lt;/ul&gt;
+          &lt;/li&gt;
+          &lt;li role="search" class="nav-main-item "&gt;
+            &lt;a class="nav-main-link" href="/search"&gt;&lt;i class='fa fa-search'&gt;&lt;/i&gt; &lt;span class='sr-only'&gt;Search&lt;/span&gt;&lt;/a&gt;&lt;/li&gt;
+        &lt;/ul&gt;
+        &lt;ul class="nav-secondary" role="menubar"&gt;
+          &lt;li role="menuitem" class="nav-secondary-item"&gt;
+            &lt;a class="nav-secondary-link" href="http://blog.dilbert.com/about"&gt;About Dilbert&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" class="nav-secondary-item"&gt;
+            &lt;a class="nav-secondary-link" target="_blank" href="https://www.andrewsmcmeel.com/privacy-policy"&gt;Privacy&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" class="nav-secondary-item"&gt;
+            &lt;a class="nav-secondary-link" target="_blank" href="https://www.andrewsmcmeel.com/privacy-policy"&gt;Cookies&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" class="nav-secondary-item"&gt;
+            &lt;a class="nav-secondary-link" href="http://blog.dilbert.com/advertising"&gt;Advertising&lt;/a&gt;
+          &lt;/li&gt;
+          &lt;li role="menuitem" class="nav-secondary-item"&gt;
+            &lt;a class="nav-secondary-link" href="http://blog.dilbert.com/contact"&gt;Contact&lt;/a&gt;
+          &lt;/li&gt;
+        &lt;/ul&gt;
+      &lt;/nav&gt;
+    &lt;/div&gt;
+    &lt;!-- /.site-header-nav --&gt;
+    &lt;div class="site-header-mobile-search"&gt;
+      &lt;form action="/search_results" method="get"&gt;
+        &lt;div class="form-group"&gt;
+          &lt;input type="text" name="terms" id="terms" class="form-control input-lg" placeholder="Search by Keyword or Date" /&gt;
+        &lt;/div&gt;
+        &lt;div class="form-group"&gt;
+          &lt;button name="" type="sumbit" class="btn btn-block btn-primary btn-lg"&gt;
+            &lt;i class='fa fa-search'&gt;&lt;/i&gt; Search
+&lt;/button&gt;        &lt;/div&gt;
+      &lt;/form&gt;
+    &lt;/div&gt;
+  &lt;/header&gt;
+  &lt;!-- /.site-header --&gt;
+&lt;/div&gt;
+&lt;!-- /.container-header --&gt;
+&lt;!-- HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END HEADER END --&gt;
+          &lt;div class="ad-leaderboard" aria-hidden="true"&gt;
+    &lt;div id="leaderboard0" class="ad js-ad js-ad-refresh" data-ad-type="leaderboard"&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+        &lt;div class="page-wrapper content-section" role="main"&gt;
+	        
+&lt;div class="ad-anchored" aria-hidden="true"&gt;
+    &lt;div id="tower_anchored" class="ad js-ad js-ad-refresh" data-ad-type="tower_anchored"&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+&lt;h1 class="hidden" id="hidden-header"&gt;Dilbert.com by Scott Adams&lt;/h1&gt;
+
+&lt;script type='application/ld+json'&gt;
+{
+	"@context":"https://schema.org",
+	"@type":"WebSite",
+	"url":"https://www.dilbert.com",
+	"name":"Dilbert",
+	"logo":"http://dilbert.com/assets/dilbert-logo-b9a1fc1f44d5b72cb9eadcb5fa150087243ee83350dc600285879087887de0f0.png",
+	"potentialAction":{
+		"@type":"SearchAction",
+		"target":"https://www.dilbert.com/search_results?terms={search_term_string}",
+		"query-input":"required name=search_term_string"
+	},
+	"sameAs": [
+    	"https://www.facebook.com/dilbert",
+    	"https://twitter.com/Dilbert_Daily"
+  	]
+}
+&lt;/script&gt;
+
+&lt;div id="js_comics"&gt;
+    &lt;div class="js_comic_block_8339490"&gt;
+      
+&lt;div class="comic-item-container js_comic_container_2019-07-16"  accountablePerson="Andrews McMeel Syndication" creator="Scott Adams" data-itemtype="" data-id="2019-07-16" data-url="https://dilbert.com/strip/2019-07-16" data-image="//assets.amuniversal.com/c4d1b3a078c70137a69a005056a9545d" data-date="July 16, 2019" data-creator="Scott Adams" data-title="Phone Is More Interesting" data-tags="cell phone,criticism,date,dinner,entertainment,men and women,texting,smartphone" data-description="Tina:  I just realized I enjoy using my phone more than I enjoy interacting with you.  I mean, this thing is amazing, whereas you haven&amp;#39;t found a way to entertain me all night.
+Dilbert:  Maybe I&amp;#39;ll grow on you.
+Tina:  &amp;quot;Now he sounds like a tumor. LOl!&amp;quot;"&gt;
+  &lt;div class="meta-info-container"&gt;
+
+
+    &lt;section class="comic-item"&gt;
+
+      &lt;h1 class="comic-title"&gt;
+        &lt;a class="comic-title-link" href="https://dilbert.com/strip/2019-07-16"&gt;
+        &lt;span class="comic-date-wrapper"&gt;
+          &lt;date class="comic-title-date" itemProp="datePublished"&gt;
+            &lt;span&gt;Tuesday July 16,&lt;/span&gt;
+            &lt;span itemprop="copyrightYear"&gt;2019&lt;/span&gt;
+          &lt;/date&gt;
+        &lt;/span&gt;
+          &lt;span class="comic-title-name"&gt;Phone Is More Interesting&lt;/span&gt;
+        &lt;/a&gt;
+        &lt;span class="star-rating"&gt;
+          &lt;div class="star_rating_2019-07-16 js_star_rating star-rating" data-date="2019-07-16"&gt;&lt;/div&gt;
+        &lt;/span&gt;
+      &lt;/h1&gt;
+      &lt;div class="alert alert-success js_thanks_for_voting"&gt;
+          Thank you for voting.
+      &lt;/div&gt;
+
+      &lt;div class="img-comic-container"&gt;
+        &lt;a class="img-comic-link" href="https://dilbert.com/strip/2019-07-16" title="Click to see the comic strip Phone Is More Interesting"&gt;
+          &lt;img class="img-responsive img-comic" width="900" height="280" alt="Phone Is More Interesting - Dilbert by Scott Adams" src="//assets.amuniversal.com/c4d1b3a078c70137a69a005056a9545d" /&gt;
+        &lt;/a&gt;
+        &lt;meta itemprop="isFamilyFriendly" content="true"/&gt;
+
+        &lt;div data-src=".js_comic_container_2019-07-16" class="js-amu-social-section"&gt;
+          &lt;ul class="amu-section-social" role="toolbar"&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="email" class="social-btn social-btn-link js-email" href="mailto:?body=Check%20out%20this%20Dilbert%20Comic.%0D%0A%0D%0A%2F%2Fwww.dilbert.com%2Fstrip%2F2019-07-16%3Futm_source%3Ddilbert.com%2Fshare-email%26utm_medium%3Demail%26utm_campaign%3Dbrand-loyalty&amp;amp;subject=Dilbert%20by%20Scott%20Adams%2C%202019-07-16"&gt;
+                &lt;i class="fa fa-envelope fa-fw fa-lg"&gt;&lt;/i&gt; &lt;span class="sr-only"&gt;Email Comic&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="facebook" class="social-btn social-btn-facebook js-facebook share-btn" href="#"&gt;
+                &lt;i class="fa fa-facebook fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on Facebook&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="twitter" class="social-btn social-btn-twitter js-twitter share-btn" href="#"&gt;
+                &lt;i class="fa fa-twitter fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Tweet&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="linkedin" class="social-btn social-btn-linkedin js-linkedin share-btn" href="#"&gt;
+              &lt;i class="fa fa-linkedin fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on LinkedIn&lt;/span&gt;
+            &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;
+              &lt;a href="https://dilbert.com/strip/2019-07-16#comments" class="social-link" title="Join the discussion on Phone Is More Interesting Dilbert Comic Strip"&gt;
+                &lt;span class="social-link-icon"&gt;&lt;i class="fa fa-comments fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;
+                &lt;span class="social-label-stacked"&gt;
+                &lt;span class="social-label-top"&gt;Comments&lt;/span&gt;
+                &lt;span class="social-label-bottom disqus-comment-count" data-disqus-identifier="comic-2019-07-16"&gt;0&lt;/span&gt;
+              &lt;/span&gt;
+              &lt;/a&gt;
+            &lt;/li&gt;
+            &lt;li class="comic-buy-link amu-social-item"&gt;
+              &lt;a class="social-btn social-btn-link" href="/buy?date=2019-07-16" title="Purchase this strip"&gt;&lt;span class="visible-xs hidden-sm"&gt;&lt;i class="fa fa-shopping-cart fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class="hidden-xs"&gt;Buy&lt;/span&gt;&lt;/a&gt;
+            &lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/div&gt;
+
+
+        &lt;div id="js-toggle-element-2019-07-16" data-id="2019-07-16" class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;button type="button" class="close js-close-link" data-target="#js-toggle-element-2019-07-16"&gt;&lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;span class="sr-only"&gt;Close&lt;/span&gt;&lt;/button&gt;
+	&lt;h4 class="hdr-info"&gt;Share July 16, 2019's comic on:&lt;/h4&gt;
+	&lt;ul class="share-links list list-inline"&gt;
+		&lt;li&gt;&lt;a name="facebook" class="share-btn share-btn-facebook js-facebook" href="#"&gt;&lt;button class="fa fa-facebook fa-fw fa-lg" aria-label="Share on Facebook"&gt;&lt;/button&gt; Facebook&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="twitter" class="share-btn share-btn-twitter js-twitter" href="#"&gt;&lt;button class="fa fa-twitter fa-fw fa-lg" aria-label="Share on Twitter"&gt;&lt;/button&gt; Twitter&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="reddit" class="share-btn share-btn-reddit js-reddit" href="#"&gt;&lt;button class="fa fa-reddit fa-fw fa-lg" aria-label="Share on Reddit"&gt;&lt;/button&gt; Reddit&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="linkedin" class="share-btn share-btn-linkedin js-linkedin" href="#"&gt;&lt;button class="fa fa-linkedin fa-fw fa-lg" aria-label="Share on LinkedIn"&gt;&lt;/button&gt; LinkedIn&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;hr&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-16"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-16" value="https://dilbert.com/strip/2019-07-16"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+
+
+
+&lt;div id="js-toggle-element-2019-07-16-variation" data-id="2019-07-16"  class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-16"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-16" value="https://dilbert.com/strip/2019-07-16"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+        &lt;div class="meta-info-container"&gt;
+            &lt;p class="small comic-tags"&gt;
+              &lt;span class="label-sm"&gt;Tags&lt;/span&gt;
+                &lt;a class="link" href="/search_results?terms=cell+phone"&gt;#cell phone&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=criticism"&gt;#criticism&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=date"&gt;#date&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=dinner"&gt;#dinner&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=entertainment"&gt;#entertainment&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=men+and+women"&gt;#men and women&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=texting"&gt;#texting&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=smartphone"&gt;#smartphone&lt;/a&gt;
+            &lt;/p&gt;
+            &lt;p class="small"&gt;
+              &lt;a class="js-toggle-link " data-target="#js-toggle-transcript-2019-07-16" href=""&gt;View
+                Transcript&lt;/a&gt;
+            &lt;/p&gt;
+          &lt;div id="js-toggle-transcript-2019-07-16" class="js-toggle-container"&gt;
+            &lt;h4&gt;&lt;span class="label-sm"&gt;Transcript&lt;/span&gt;&lt;/h4&gt;
+            &lt;p&gt;Tina:  I just realized I enjoy using my phone more than I enjoy interacting with you.  I mean, this thing is amazing, whereas you haven&amp;#39;t found a way to entertain me all night.
+Dilbert:  Maybe I&amp;#39;ll grow on you.
+Tina:  &amp;quot;Now he sounds like a tumor. LOl!&amp;quot;&lt;/p&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/section&gt;
+  &lt;/div&gt;
+
+  &lt;script type="text/javascript"&gt;
+    $(function () {
+      $('.star_rating_2019-07-16').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+      $('.star_rating_2019-07-16').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+    });
+  &lt;/script&gt;
+
+&lt;/div&gt;
+
+
+    &lt;div class='shelf-space-container row js_shelf_ads'&gt;
+  &lt;div class="shelf-space-item"&gt;
+    &lt;div class="ad-rectangle" aria-hidden="true"&gt;
+    &lt;div id="rectangle0" class="ad js-ad js-ad-refresh" data-ad-type="rectangle"&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+  &lt;/div&gt;
+
+
+
+  &lt;div class="shelf-space-item"&gt;
+    &lt;h3 class="blog-hdr-top"&gt;&lt;a href="http://blog.dilbert.com?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-engagement&amp;amp;utm_content=shelf-space-2-blog"&gt;From Scott Adams&amp;#39; Blog&lt;/a&gt;&lt;/h3&gt;
+    &lt;div class="blog-item-multiple"&gt;
+      &lt;div class="media"&gt;
+        &lt;a class="link-blended" href="https://blog.dilbert.com/2019/07/15/episode-598-scott-adams-trumps-go-back-tweet-possible-iran-nuclear-deal/?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-engagement&amp;amp;utm_content=shelf-space-0-blog-title" title="Episode 598 Scott Adams: Trump’s “Go Back” Tweet, Possible Iran Nuclear Deal by Scott Adams"&gt;
+          &lt;div class="media-left"&gt;
+              &lt;img class="media-object" alt="" src="/assets/avatar_scottadams_128-751be3ae01272f9b970ccc9a004a02d35f13538a873d0d055371657ddfc1ab31.png" width="64" height="64" /&gt;
+          &lt;/div&gt;
+          &lt;div class="media-body"&gt;
+            &lt;h4 class="media-heading"&gt;Episode 598 Scott Adams: Trump’s “Go Back” Tweet, Possible Iran Nuclear Deal&lt;/h4&gt;
+            &lt;span class="blog-author"&gt;by Scott Adams&lt;/span&gt;
+          &lt;/div&gt;
+        &lt;/a&gt;
+      &lt;/div&gt;
+
+
+      &lt;div class="media"&gt;
+        &lt;a class="link-blended" href="https://blog.dilbert.com/2019/07/14/episode-597-scott-adams-bubonic-plague-mind-reading-british-diplomats-chat-with-carpedonktum/?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-engagement&amp;amp;utm_content=shelf-space-0-blog-title" title="Episode 597 Scott Adams: Bubonic Plague, Mind-Reading British Diplomats, Chat With @CarpeDonktum by Scott Adams"&gt;
+          &lt;div class="media-left"&gt;
+              &lt;img class="media-object" alt="" src="/assets/avatar_scottadams_128-751be3ae01272f9b970ccc9a004a02d35f13538a873d0d055371657ddfc1ab31.png" width="64" height="64" /&gt;
+          &lt;/div&gt;
+          &lt;div class="media-body"&gt;
+            &lt;h4 class="media-heading"&gt;Episode 597 Scott Adams: Bubonic Plague, Mind-Reading British Diplomats, Chat With @CarpeDonktum&lt;/h4&gt;
+            &lt;span class="blog-author"&gt;by Scott Adams&lt;/span&gt;
+          &lt;/div&gt;
+        &lt;/a&gt;
+      &lt;/div&gt;
+
+      
+      &lt;div class="media"&gt;
+        &lt;a class="link-blended" href="https://blog.dilbert.com/2019/07/13/episode-596-scott-adams-vp-pence-visits-border-kanye-building-homes-audience-questions/?utm_source=dilbert.com&amp;amp;utm_medium=site&amp;amp;utm_campaign=brand-engagement&amp;amp;utm_content=shelf-space-0-blog-title" title="Episode 596 Scott Adams: VP Pence Visits Border, Kanye Building Homes, Audience Questions by Scott Adams"&gt;
+          &lt;div class="media-left"&gt;
+              &lt;img class="media-object" alt="" src="/assets/avatar_scottadams_128-751be3ae01272f9b970ccc9a004a02d35f13538a873d0d055371657ddfc1ab31.png" width="64" height="64" /&gt;
+          &lt;/div&gt;
+          &lt;div class="media-body"&gt;
+            &lt;h4 class="media-heading"&gt;Episode 596 Scott Adams: VP Pence Visits Border, Kanye Building Homes, Audience Questions&lt;/h4&gt;
+            &lt;span class="blog-author"&gt;by Scott Adams&lt;/span&gt;
+          &lt;/div&gt;
+        &lt;/a&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+
+
+
+  &lt;div class="shelf-space-item shelf-space-item-right"&gt;
+    &lt;div class="ad-rectangle-right" aria-hidden="true"&gt;
+    &lt;div id="rectangle_right0" class="ad js-ad js-ad-refresh" data-ad-type="rectangle_right"&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+
+
+
+
+      
+&lt;div class="comic-item-container js_comic_container_2019-07-15"  accountablePerson="Andrews McMeel Syndication" creator="Scott Adams" data-itemtype="" data-id="2019-07-15" data-url="https://dilbert.com/strip/2019-07-15" data-image="//assets.amuniversal.com/989e6c2078c50137a69a005056a9545d" data-date="July 15, 2019" data-creator="Scott Adams" data-title="More People Working At Home" data-tags="boss,employees,office,office workers" data-description="Boss:  The office is too quiet today.
+Carol:  That&amp;#39;s because more people are working from home.
+Boss:  How can I do my job if I can&amp;#39;t pop into people&amp;#39;s cubicles and share my wisdom?  Second question: why is everything running so smoothly lately?"&gt;
+  &lt;div class="meta-info-container"&gt;
+
+
+    &lt;section class="comic-item"&gt;
+
+      &lt;h1 class="comic-title"&gt;
+        &lt;a class="comic-title-link" href="https://dilbert.com/strip/2019-07-15"&gt;
+        &lt;span class="comic-date-wrapper"&gt;
+          &lt;date class="comic-title-date" itemProp="datePublished"&gt;
+            &lt;span&gt;Monday July 15,&lt;/span&gt;
+            &lt;span itemprop="copyrightYear"&gt;2019&lt;/span&gt;
+          &lt;/date&gt;
+        &lt;/span&gt;
+          &lt;span class="comic-title-name"&gt;More People Working At Home&lt;/span&gt;
+        &lt;/a&gt;
+        &lt;span class="star-rating"&gt;
+          &lt;div class="star_rating_2019-07-15 js_star_rating star-rating" data-date="2019-07-15"&gt;&lt;/div&gt;
+        &lt;/span&gt;
+      &lt;/h1&gt;
+      &lt;div class="alert alert-success js_thanks_for_voting"&gt;
+          Thank you for voting.
+      &lt;/div&gt;
+
+      &lt;div class="img-comic-container"&gt;
+        &lt;a class="img-comic-link" href="https://dilbert.com/strip/2019-07-15" title="Click to see the comic strip More People Working At Home"&gt;
+          &lt;img class="img-responsive img-comic" width="900" height="280" alt="More People Working At Home - Dilbert by Scott Adams" src="//assets.amuniversal.com/989e6c2078c50137a69a005056a9545d" /&gt;
+        &lt;/a&gt;
+        &lt;meta itemprop="isFamilyFriendly" content="true"/&gt;
+
+        &lt;div data-src=".js_comic_container_2019-07-15" class="js-amu-social-section"&gt;
+          &lt;ul class="amu-section-social" role="toolbar"&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="email" class="social-btn social-btn-link js-email" href="mailto:?body=Check%20out%20this%20Dilbert%20Comic.%0D%0A%0D%0A%2F%2Fwww.dilbert.com%2Fstrip%2F2019-07-15%3Futm_source%3Ddilbert.com%2Fshare-email%26utm_medium%3Demail%26utm_campaign%3Dbrand-loyalty&amp;amp;subject=Dilbert%20by%20Scott%20Adams%2C%202019-07-15"&gt;
+                &lt;i class="fa fa-envelope fa-fw fa-lg"&gt;&lt;/i&gt; &lt;span class="sr-only"&gt;Email Comic&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="facebook" class="social-btn social-btn-facebook js-facebook share-btn" href="#"&gt;
+                &lt;i class="fa fa-facebook fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on Facebook&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="twitter" class="social-btn social-btn-twitter js-twitter share-btn" href="#"&gt;
+                &lt;i class="fa fa-twitter fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Tweet&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="linkedin" class="social-btn social-btn-linkedin js-linkedin share-btn" href="#"&gt;
+              &lt;i class="fa fa-linkedin fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on LinkedIn&lt;/span&gt;
+            &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;
+              &lt;a href="https://dilbert.com/strip/2019-07-15#comments" class="social-link" title="Join the discussion on More People Working At Home Dilbert Comic Strip"&gt;
+                &lt;span class="social-link-icon"&gt;&lt;i class="fa fa-comments fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;
+                &lt;span class="social-label-stacked"&gt;
+                &lt;span class="social-label-top"&gt;Comments&lt;/span&gt;
+                &lt;span class="social-label-bottom disqus-comment-count" data-disqus-identifier="comic-2019-07-15"&gt;0&lt;/span&gt;
+              &lt;/span&gt;
+              &lt;/a&gt;
+            &lt;/li&gt;
+            &lt;li class="comic-buy-link amu-social-item"&gt;
+              &lt;a class="social-btn social-btn-link" href="/buy?date=2019-07-15" title="Purchase this strip"&gt;&lt;span class="visible-xs hidden-sm"&gt;&lt;i class="fa fa-shopping-cart fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class="hidden-xs"&gt;Buy&lt;/span&gt;&lt;/a&gt;
+            &lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/div&gt;
+
+
+        &lt;div id="js-toggle-element-2019-07-15" data-id="2019-07-15" class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;button type="button" class="close js-close-link" data-target="#js-toggle-element-2019-07-15"&gt;&lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;span class="sr-only"&gt;Close&lt;/span&gt;&lt;/button&gt;
+	&lt;h4 class="hdr-info"&gt;Share July 15, 2019's comic on:&lt;/h4&gt;
+	&lt;ul class="share-links list list-inline"&gt;
+		&lt;li&gt;&lt;a name="facebook" class="share-btn share-btn-facebook js-facebook" href="#"&gt;&lt;button class="fa fa-facebook fa-fw fa-lg" aria-label="Share on Facebook"&gt;&lt;/button&gt; Facebook&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="twitter" class="share-btn share-btn-twitter js-twitter" href="#"&gt;&lt;button class="fa fa-twitter fa-fw fa-lg" aria-label="Share on Twitter"&gt;&lt;/button&gt; Twitter&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="reddit" class="share-btn share-btn-reddit js-reddit" href="#"&gt;&lt;button class="fa fa-reddit fa-fw fa-lg" aria-label="Share on Reddit"&gt;&lt;/button&gt; Reddit&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="linkedin" class="share-btn share-btn-linkedin js-linkedin" href="#"&gt;&lt;button class="fa fa-linkedin fa-fw fa-lg" aria-label="Share on LinkedIn"&gt;&lt;/button&gt; LinkedIn&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;hr&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-15"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-15" value="https://dilbert.com/strip/2019-07-15"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+
+
+
+&lt;div id="js-toggle-element-2019-07-15-variation" data-id="2019-07-15"  class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-15"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-15" value="https://dilbert.com/strip/2019-07-15"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+        &lt;div class="meta-info-container"&gt;
+            &lt;p class="small comic-tags"&gt;
+              &lt;span class="label-sm"&gt;Tags&lt;/span&gt;
+                &lt;a class="link" href="/search_results?terms=boss"&gt;#boss&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=employees"&gt;#employees&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=office"&gt;#office&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=office+workers"&gt;#office workers&lt;/a&gt;
+            &lt;/p&gt;
+            &lt;p class="small"&gt;
+              &lt;a class="js-toggle-link " data-target="#js-toggle-transcript-2019-07-15" href=""&gt;View
+                Transcript&lt;/a&gt;
+            &lt;/p&gt;
+          &lt;div id="js-toggle-transcript-2019-07-15" class="js-toggle-container"&gt;
+            &lt;h4&gt;&lt;span class="label-sm"&gt;Transcript&lt;/span&gt;&lt;/h4&gt;
+            &lt;p&gt;Boss:  The office is too quiet today.
+Carol:  That&amp;#39;s because more people are working from home.
+Boss:  How can I do my job if I can&amp;#39;t pop into people&amp;#39;s cubicles and share my wisdom?  Second question: why is everything running so smoothly lately?&lt;/p&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/section&gt;
+  &lt;/div&gt;
+
+  &lt;script type="text/javascript"&gt;
+    $(function () {
+      $('.star_rating_2019-07-15').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+      $('.star_rating_2019-07-15').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+    });
+  &lt;/script&gt;
+
+&lt;/div&gt;
+
+
+
+
+      
+&lt;div class="comic-item-container js_comic_container_2019-07-14"  accountablePerson="Andrews McMeel Syndication" creator="Scott Adams" data-itemtype="" data-id="2019-07-14" data-url="https://dilbert.com/strip/2019-07-14" data-image="//assets.amuniversal.com/3f5c29a05f0f01379d9a005056a9545d" data-date="July 14, 2019" data-creator="Scott Adams" data-title="Finding A Scapegoat" data-tags="business,office,project,ceo,scapegaot,climate change" data-description="the boss: we&amp;#39;ll need a scapegoat to blame for our failure on this project.
+dilbert: no one will believe it wasn&amp;#39;t our fault.
+the boss: are you kidding?
+the boss: people will believe anything.
+the boss: we just have to be the first to frame the situation.
+dilbert: i suppose we could make our lie sound credible.
+the boss: that&amp;#39;s overkill.
+dilbert: we don&amp;#39;t need to sound credible?
+ the boss: not even a little.
+the boss is in ceo&amp;#39;s office.
+the boss: our project failed because of climate change.
+ceo: that sounds right."&gt;
+  &lt;div class="meta-info-container"&gt;
+
+
+    &lt;section class="comic-item"&gt;
+
+      &lt;h1 class="comic-title"&gt;
+        &lt;a class="comic-title-link" href="https://dilbert.com/strip/2019-07-14"&gt;
+        &lt;span class="comic-date-wrapper"&gt;
+          &lt;date class="comic-title-date" itemProp="datePublished"&gt;
+            &lt;span&gt;Sunday July 14,&lt;/span&gt;
+            &lt;span itemprop="copyrightYear"&gt;2019&lt;/span&gt;
+          &lt;/date&gt;
+        &lt;/span&gt;
+          &lt;span class="comic-title-name"&gt;Finding A Scapegoat&lt;/span&gt;
+        &lt;/a&gt;
+        &lt;span class="star-rating"&gt;
+          &lt;div class="star_rating_2019-07-14 js_star_rating star-rating" data-date="2019-07-14"&gt;&lt;/div&gt;
+        &lt;/span&gt;
+      &lt;/h1&gt;
+      &lt;div class="alert alert-success js_thanks_for_voting"&gt;
+          Thank you for voting.
+      &lt;/div&gt;
+
+      &lt;div class="img-comic-container"&gt;
+        &lt;a class="img-comic-link" href="https://dilbert.com/strip/2019-07-14" title="Click to see the comic strip Finding A Scapegoat"&gt;
+          &lt;img class="img-responsive img-comic" width="900" height="439" alt="Finding A Scapegoat - Dilbert by Scott Adams" src="//assets.amuniversal.com/3f5c29a05f0f01379d9a005056a9545d" /&gt;
+        &lt;/a&gt;
+        &lt;meta itemprop="isFamilyFriendly" content="true"/&gt;
+
+        &lt;div data-src=".js_comic_container_2019-07-14" class="js-amu-social-section"&gt;
+          &lt;ul class="amu-section-social" role="toolbar"&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="email" class="social-btn social-btn-link js-email" href="mailto:?body=Check%20out%20this%20Dilbert%20Comic.%0D%0A%0D%0A%2F%2Fwww.dilbert.com%2Fstrip%2F2019-07-14%3Futm_source%3Ddilbert.com%2Fshare-email%26utm_medium%3Demail%26utm_campaign%3Dbrand-loyalty&amp;amp;subject=Dilbert%20by%20Scott%20Adams%2C%202019-07-14"&gt;
+                &lt;i class="fa fa-envelope fa-fw fa-lg"&gt;&lt;/i&gt; &lt;span class="sr-only"&gt;Email Comic&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="facebook" class="social-btn social-btn-facebook js-facebook share-btn" href="#"&gt;
+                &lt;i class="fa fa-facebook fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on Facebook&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="twitter" class="social-btn social-btn-twitter js-twitter share-btn" href="#"&gt;
+                &lt;i class="fa fa-twitter fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Tweet&lt;/span&gt;
+              &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;&lt;a name="linkedin" class="social-btn social-btn-linkedin js-linkedin share-btn" href="#"&gt;
+              &lt;i class="fa fa-linkedin fa-fw fa-lg"&gt;&lt;/i&gt;&lt;span class="sr-only"&gt; Share on LinkedIn&lt;/span&gt;
+            &lt;/a&gt;&lt;/li&gt;
+            &lt;li class="amu-social-item"&gt;
+              &lt;a href="https://dilbert.com/strip/2019-07-14#comments" class="social-link" title="Join the discussion on Finding A Scapegoat Dilbert Comic Strip"&gt;
+                &lt;span class="social-link-icon"&gt;&lt;i class="fa fa-comments fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;
+                &lt;span class="social-label-stacked"&gt;
+                &lt;span class="social-label-top"&gt;Comments&lt;/span&gt;
+                &lt;span class="social-label-bottom disqus-comment-count" data-disqus-identifier="comic-2019-07-14"&gt;0&lt;/span&gt;
+              &lt;/span&gt;
+              &lt;/a&gt;
+            &lt;/li&gt;
+            &lt;li class="comic-buy-link amu-social-item"&gt;
+              &lt;a class="social-btn social-btn-link" href="/buy?date=2019-07-14" title="Purchase this strip"&gt;&lt;span class="visible-xs hidden-sm"&gt;&lt;i class="fa fa-shopping-cart fa-lg fa-fw"&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class="hidden-xs"&gt;Buy&lt;/span&gt;&lt;/a&gt;
+            &lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/div&gt;
+
+
+        &lt;div id="js-toggle-element-2019-07-14" data-id="2019-07-14" class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;button type="button" class="close js-close-link" data-target="#js-toggle-element-2019-07-14"&gt;&lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;span class="sr-only"&gt;Close&lt;/span&gt;&lt;/button&gt;
+	&lt;h4 class="hdr-info"&gt;Share July 14, 2019's comic on:&lt;/h4&gt;
+	&lt;ul class="share-links list list-inline"&gt;
+		&lt;li&gt;&lt;a name="facebook" class="share-btn share-btn-facebook js-facebook" href="#"&gt;&lt;button class="fa fa-facebook fa-fw fa-lg" aria-label="Share on Facebook"&gt;&lt;/button&gt; Facebook&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="twitter" class="share-btn share-btn-twitter js-twitter" href="#"&gt;&lt;button class="fa fa-twitter fa-fw fa-lg" aria-label="Share on Twitter"&gt;&lt;/button&gt; Twitter&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="reddit" class="share-btn share-btn-reddit js-reddit" href="#"&gt;&lt;button class="fa fa-reddit fa-fw fa-lg" aria-label="Share on Reddit"&gt;&lt;/button&gt; Reddit&lt;/a&gt;&lt;/li&gt;
+
+		&lt;li&gt;&lt;a name="linkedin" class="share-btn share-btn-linkedin js-linkedin" href="#"&gt;&lt;button class="fa fa-linkedin fa-fw fa-lg" aria-label="Share on LinkedIn"&gt;&lt;/button&gt; LinkedIn&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;hr&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-14"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-14" value="https://dilbert.com/strip/2019-07-14"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+
+
+
+&lt;div id="js-toggle-element-2019-07-14-variation" data-id="2019-07-14"  class="alert alert-info alert-share js-track-share-toggle"&gt;
+	&lt;form class="form form-inline"&gt;
+		&lt;label class="control-label" for="link-2019-07-14"&gt;Grab the link:&lt;/label&gt;
+		&lt;input class="form-control js-copy-link input-share-link" name="link-2019-07-14" value="https://dilbert.com/strip/2019-07-14"&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+        &lt;div class="meta-info-container"&gt;
+            &lt;p class="small comic-tags"&gt;
+              &lt;span class="label-sm"&gt;Tags&lt;/span&gt;
+                &lt;a class="link" href="/search_results?terms=business"&gt;#business&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=office"&gt;#office&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=project"&gt;#project&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=ceo"&gt;#ceo&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=scapegaot"&gt;#scapegaot&lt;/a&gt;,
+                &lt;a class="link" href="/search_results?terms=climate+change"&gt;#climate change&lt;/a&gt;
+            &lt;/p&gt;
+            &lt;p class="small"&gt;
+              &lt;a class="js-toggle-link " data-target="#js-toggle-transcript-2019-07-14" href=""&gt;View
+                Transcript&lt;/a&gt;
+            &lt;/p&gt;
+          &lt;div id="js-toggle-transcript-2019-07-14" class="js-toggle-container"&gt;
+            &lt;h4&gt;&lt;span class="label-sm"&gt;Transcript&lt;/span&gt;&lt;/h4&gt;
+            &lt;p&gt;the boss: we&amp;#39;ll need a scapegoat to blame for our failure on this project.
+dilbert: no one will believe it wasn&amp;#39;t our fault.
+the boss: are you kidding?
+the boss: people will believe anything.
+the boss: we just have to be the first to frame the situation.
+dilbert: i suppose we could make our lie sound credible.
+the boss: that&amp;#39;s overkill.
+dilbert: we don&amp;#39;t need to sound credible?
+ the boss: not even a little.
+the boss is in ceo&amp;#39;s office.
+the boss: our project failed because of climate change.
+ceo: that sounds right.&lt;/p&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/section&gt;
+  &lt;/div&gt;
+
+  &lt;script type="text/javascript"&gt;
+    $(function () {
+      $('.star_rating_2019-07-14').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+      $('.star_rating_2019-07-14').raty({
+        score: 4.5,
+        half: true,
+        precision: false
+      });
+    });
+  &lt;/script&gt;
+
+&lt;/div&gt;
+
+
+    &lt;div class="ad-banner" aria-hidden="true"&gt;
+    &lt;div id="banner0" class="ad js-ad-lazy-load js-ad-refresh" data-ad-type="banner"&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+
+
+  &lt;/div&gt;
+  
+
+&lt;/div&gt;
+
+&lt;div id="infinite-scrolling" class="infinite-scrolling-container"&gt;
+  &lt;a class="js_load_comics pagination" href="/?post_index=3&amp;amp;series_count=0&amp;amp;starting_point=3"&gt;&lt;p&gt;&lt;i class="fa fa-refresh fa-2x"&gt;&lt;/i&gt;&lt;/p&gt;&lt;p class="text-muted js-load-comics-text"&gt;Load More&lt;/p&gt;&lt;/a&gt;
+&lt;/div&gt;
+
+&lt;script src="/assets/disqus-aaccaa13d7722a7ec0b3053e511b0517ac8cb350ddb93548954dee6c6d1215ce.js"&gt;&lt;/script&gt;
+
+        &lt;/div&gt;
+    &lt;/div&gt;
+
+    &lt;div class="ad-locked" aria-hidden="true"&gt;
+  &lt;div id="tynt" class="js-ad" data-ad-type="tynt"&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+    &lt;div class="ad-venatus" aria-hidden="true"&gt;
+  &lt;div id="venatus" class="js-ad" data-ad-type="venatus"&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+    &lt;!-- Quantcast Tag --&gt;
+&lt;script type="text/javascript"&gt;
+    var _qevents = _qevents || [];
+
+    (function() {
+        var elem = document.createElement('script');
+        elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+        elem.async = true;
+        elem.type = "text/javascript";
+        var scpt = document.getElementsByTagName('script')[0];
+        scpt.parentNode.insertBefore(elem, scpt);
+    })();
+
+    _qevents.push({
+        qacct:"p-5bhew76JBcfq6"
+    });
+&lt;/script&gt;
+
+&lt;noscript&gt;
+  &lt;div style="display:none;"&gt;
+    &lt;img src="//pixel.quantserve.com/pixel/p-5bhew76JBcfq6.gif" border="0" height="1" width="1" alt=""/&gt;
+  &lt;/div&gt;
+&lt;/noscript&gt;
+&lt;!-- End Quantcast tag --&gt;
+
+    &lt;script src="/assets/apollo-759f6f2ba681ee0e19fb93c9b53715806430656f53154427bc5eb3e1560bf28a.js?sampling=2&amp;tracker=trackerUU47"&gt;&lt;/script&gt;
+&lt;/body&gt;
+&lt;/html&gt;
+</ReturnValue>
+    <OutAndRefValues />
+  </RecordedCall>
+</ArrayOfRecordedCall>


### PR DESCRIPTION
Currently, the configuration is one long, complicated line. Let's make it many slightly shorter complicated lines, read from a Google Doc. With various improvement
1. the app doesn't get redeployed every time I make a config change
2. it's easier to read the configuration
3. allow commented-out lines so subscribers can be excluded from test runs
4. allow the opposite - a mode where selected subscribers are the only ones to receive comics
